### PR TITLE
IsTest function for top 10 languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ The most accurate guess would be one when both, the file name and the content ar
  - `IsDocumentation`
  - `IsDotFile`
  - `IsImage`
+ - `IsTest`
 
 ### Language colors and groups
 *enry* exposes function to get language color to use for example in presenting statistics in graphs:

--- a/data/test.go
+++ b/data/test.go
@@ -1,0 +1,17 @@
+package data
+
+import "gopkg.in/toqueteos/substring.v1"
+
+// TestMatchers is hand made collection of regexp used by the function `enry.IsTest`
+// to identify test files in different languages.
+var TestMatchers = substring.Or(
+	substring.Regexp(`(^|/)tests/.*Test\.php$`),
+	substring.Regexp(`(^|/)test/.*Test(s?)\.java$`),
+	substring.Regexp(`(^|/)test(/|/.*/)Test.*\.java$`),
+	substring.Regexp(`(^|/)test/.*(Test(s?)|Spec(s?))\.scala$`),
+	substring.Regexp(`(^|/)test_.*\.py$`),
+	substring.Regexp(`(^|/).*_test\.go$`),
+	substring.Regexp(`(^|/).*_(test|spec)\.rb$`),
+	substring.Regexp(`(^|/).*Test(s?)\.cs$`),
+	substring.Regexp(`(^|/).*\.(test|spec)\.(ts|tsx|js)$`),
+)

--- a/utils.go
+++ b/utils.go
@@ -60,6 +60,11 @@ func IsVendor(path string) bool {
 	return data.VendorMatchers.Match(path)
 }
 
+// IsTest returns whether or not path is a test path.
+func IsTest(path string) bool {
+	return data.TestMatchers.Match(path)
+}
+
 // IsBinary detects if data is a binary value based on:
 // http://git.kernel.org/cgit/git/git.git/tree/xdiff-interface.c?id=HEAD#n198
 func IsBinary(data []byte) bool {

--- a/utils_test.go
+++ b/utils_test.go
@@ -133,6 +133,47 @@ func TestIsDotFile(t *testing.T) {
 		assert.Equal(t, test.expected, is, fmt.Sprintf("%v: is = %v, expected: %v", test.name, is, test.expected))
 	}
 }
+func TestIsTestFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{name: "TestPHP_Is", path: "tests/FooTest.php", expected: true},
+		{name: "TestPHP_Not", path: "foo/FooTest.php", expected: false},
+		{name: "TestJava_Is_1", path: "test/FooTest.java", expected: true},
+		{name: "TestJava_Is_2", path: "test/FooTests.java", expected: true},
+		{name: "TestJava_Is_3", path: "test/TestFoo.java", expected: true},
+		{name: "TestJava_Is_4", path: "test/qux/TestFoo.java", expected: true},
+		{name: "TestJava_Not", path: "foo/FooTest.java", expected: false},
+		{name: "TestScala_Is_1", path: "test/FooTest.scala", expected: true},
+		{name: "TestScala_Is_2", path: "test/FooTests.scala", expected: true},
+		{name: "TestScala_Is_3", path: "test/FooSpec.scala", expected: true},
+		{name: "TestScala_Is_4", path: "test/qux/FooSpecs.scala", expected: true},
+		{name: "TestScala_Not", path: "foo/FooTest.scala", expected: false},
+		{name: "TestPython_Is", path: "test_foo.py", expected: true},
+		{name: "TestPython_Not", path: "foo_test.py", expected: false},
+		{name: "TestGo_Is", path: "foo_test.go", expected: true},
+		{name: "TestGo_Not", path: "test_foo.go", expected: false},
+		{name: "TestRuby_Is_1", path: "foo_test.rb", expected: true},
+		{name: "TestRuby_Is_1", path: "foo_spec.rb", expected: true},
+		{name: "TestRuby_Not", path: "foo_specs.rb", expected: false},
+		{name: "TestCSharp_Is_1", path: "FooTest.cs", expected: true},
+		{name: "TestCSharp_Is_2", path: "foo/FooTests.cs", expected: true},
+		{name: "TestCSharp_Not", path: "foo/TestFoo.cs", expected: false},
+		{name: "TestJavaScript_Is_1", path: "foo.test.js", expected: true},
+		{name: "TestJavaScript_Is_2", path: "foo.spec.js", expected: true},
+		{name: "TestJavaScript_Not", path: "footest.js", expected: false},
+		{name: "TestTypeScript_Is_1", path: "foo.test.ts", expected: true},
+		{name: "TestTypeScript_Is_2", path: "foo.spec.ts", expected: true},
+		{name: "TestTypeScript_Not", path: "footest.ts", expected: false},
+	}
+
+	for _, test := range tests {
+		is := IsTest(test.path)
+		assert.Equal(t, test.expected, is, fmt.Sprintf("%v: is = %v, expected: %v", test.name, is, test.expected))
+	}
+}
 
 func TestGetColor(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This PRs adds a new function called `IsTest` to validate if a given path is a test file or not. It implements rules for the top 10 languages, not including C/C++.