### PR TITLE
WIP python: generate bindings automatically using gopy

### DIFF
--- a/common.go
+++ b/common.go
@@ -142,7 +142,7 @@ func GetLanguages(filename string, content []byte) []string {
 
 // GetLanguagesByModeline returns a slice of possible languages for the given content.
 // It complies with the signature to be a Strategy type.
-func GetLanguagesByModeline(_ string, content []byte, candidates []string) []string {
+func GetLanguagesByModeline(filename string, content []byte, candidates []string) []string {
 	headFoot := getHeaderAndFooter(content)
 	var languages []string
 	for _, getLang := range modelinesFunc {
@@ -207,7 +207,7 @@ var (
 
 // GetLanguagesByEmacsModeline returns a slice of possible languages for the given content.
 // It complies with the signature to be a Strategy type.
-func GetLanguagesByEmacsModeline(_ string, content []byte, _ []string) []string {
+func GetLanguagesByEmacsModeline(filename string, content []byte, candidates []string) []string {
 	matched := reEmacsModeline.FindAllSubmatch(content, -1)
 	if matched == nil {
 		return nil
@@ -233,7 +233,7 @@ func GetLanguagesByEmacsModeline(_ string, content []byte, _ []string) []string 
 
 // GetLanguagesByVimModeline returns a slice of possible languages for the given content.
 // It complies with the signature to be a Strategy type.
-func GetLanguagesByVimModeline(_ string, content []byte, _ []string) []string {
+func GetLanguagesByVimModeline(filename string, content []byte, candidates []string) []string {
 	matched := reVimModeline.FindAllSubmatch(content, -1)
 	if matched == nil {
 		return nil
@@ -269,7 +269,7 @@ func GetLanguagesByVimModeline(_ string, content []byte, _ []string) []string {
 
 // GetLanguagesByFilename returns a slice of possible languages for the given filename.
 // It complies with the signature to be a Strategy type.
-func GetLanguagesByFilename(filename string, _ []byte, _ []string) []string {
+func GetLanguagesByFilename(filename string, content []byte, candidates []string) []string {
 	if filename == "" {
 		return nil
 	}
@@ -279,7 +279,7 @@ func GetLanguagesByFilename(filename string, _ []byte, _ []string) []string {
 
 // GetLanguagesByShebang returns a slice of possible languages for the given content.
 // It complies with the signature to be a Strategy type.
-func GetLanguagesByShebang(_ string, content []byte, _ []string) (languages []string) {
+func GetLanguagesByShebang(filename string, content []byte, candidates []string) (languages []string) {
 	interpreter := getInterpreter(content)
 	return data.LanguagesByInterpreter[interpreter]
 }
@@ -365,7 +365,7 @@ func lookForMultilineExec(data []byte) string {
 
 // GetLanguagesByExtension returns a slice of possible languages for the given filename.
 // It complies with the signature to be a Strategy type.
-func GetLanguagesByExtension(filename string, _ []byte, _ []string) []string {
+func GetLanguagesByExtension(filename string, content []byte, candidates []string) []string {
 	if !strings.Contains(filename, ".") {
 		return nil
 	}
@@ -396,7 +396,7 @@ func getDotIndexes(filename string) []int {
 
 // GetLanguagesByContent returns a slice of languages for the given content.
 // It is a Strategy that uses content-based regexp heuristics and a filename extension.
-func GetLanguagesByContent(filename string, content []byte, _ []string) []string {
+func GetLanguagesByContent(filename string, content []byte, candidates []string) []string {
 	if filename == "" {
 		return nil
 	}

--- a/python/README.md
+++ b/python/README.md
@@ -21,8 +21,26 @@ $ python enry.py
 
 ## TODOs
  - [x] helpers for sending/receiving Go slices to C
- - [x] read `libenry.h` and generate `ffibuilder.cdef(...)` content
+ - [ ] automate reading `libenry.h` and generating `ffibuilder.cdef(...)` content from it
  - [x] cover the rest of enry API
  - [x] add `setup.py`
  - [ ] build/release automation on CI (publish on pypi)
  - [ ] try ABI mode, to avoid dependency on C compiler on install (+perf test?)
+
+ ## (experimental) generate bindings using gopy
+> [gopy](https://github.com/go-python/gopy) generates (and compiles) a CPython extension module from a go package.
+
+```
+# install deps
+python3 -m pip install pybindgen
+go get golang.org/x/tools/cmd/goimports
+go get github.com/go-python/gopy
+
+# generate & build
+gopy gen -output=out github.com/go-enry/go-enry/v2
+cd out
+make
+
+# use
+python -c 'import enry; enry.IsVendor("vendors/")'
+```


### PR DESCRIPTION
This is an experiment in auto-generating Python bindings using https://github.com/go-python/gopy

It requires getting rid of blank identifiers from Go API surface, that otherwise breaks compilation of generated Go code with https://github.com/golang/go/issues/15481. I believe this not to be a breaking change, at least on the Go API level.

It simplifies maintenance, as the whole API surface gets exposed automatically and there is no need to deal with CPython on enry side.

Resulting `_enry.so` is 64Kb and by default, works on macOS and Linux.

TODO:
 - [x] bindings generation + docs
 - [x] ~a very basic CI~ handled in #30 
 - [ ] integrate into `setup.py` & cleanup