### PR TITLE
CI for Python bindings

### DIFF
--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -1,5 +1,5 @@
 on: [push, pull_request]
-name: Test
+name: Go Tests
 jobs:
   test:
     strategy:
@@ -12,7 +12,6 @@ jobs:
       uses: actions/setup-go@v1
       with:
         go-version: ${{ matrix.go-version }}
-
     - name: Set git on win to use LF
       run: |
         git config --global core.autocrlf false
@@ -23,6 +22,7 @@ jobs:
       run: go test ./...
       env:
         ENRY_DEBUG: 1
+
   test-oniguruma:
     strategy:
       matrix:
@@ -37,7 +37,7 @@ jobs:
         sudo dpkg -i "libonig5_${ONIGURUMA_VERSION}-1_amd64.deb"
         wget "http://archive.ubuntu.com/ubuntu/pool/universe/libo/libonig/libonig-dev_${ONIGURUMA_VERSION}-1_amd64.deb"
         sudo dpkg -i "libonig-dev_${ONIGURUMA_VERSION}-1_amd64.deb"
-  
+
     - name: Install Go
       uses: actions/setup-go@v1
       with:

--- a/.github/workflows/pyTest.yml
+++ b/.github/workflows/pyTest.yml
@@ -1,0 +1,27 @@
+on: [push, pull_request]
+name: Python Tests
+jobs:
+  test:
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r python/requirements.txt
+        if [ -f python/requirements.dev.txt ]; then pip install -r python/requirements.dev.txt; fi
+    - name: Build and install package
+      run: |
+        pip install -e python
+    - name: Test
+      run: |
+        pytest python/

--- a/python/README.md
+++ b/python/README.md
@@ -5,7 +5,8 @@ Python bindings through cFFI (API, out-of-line) for calling enry Go functions ex
 ## Build
 
 ```
-$ cd .. && make static
+$ pushd .. && make static && popd
+$ pip install -r requirments.txt
 $ python build_enry.py
 ```
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -12,7 +12,7 @@ logger = getLogger(__name__)
 def build_go_archive():
     logger.info("Building C archive with static library")
     if shutil.which("go") is None:
-        raise EnvironmentError("You should have go installed and available on your path in order to build this module")
+        raise EnvironmentError("You should have Go installed and available on your path in order to build this module")
     subprocess.check_output(["make", "static"], cwd="../")
     logger.info("C archive successfully built")
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -31,6 +31,9 @@ class build_static_and_install(install):
         super(build_static_and_install, self).run()
 
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name="enry",
     version="0.1.1",


### PR DESCRIPTION
Fixes #14 by adding a simple profile for running python tests on linux and mac as part of CI.
Does not include any release automation.