### PR TITLE
Fix typo in the pip command in README.md

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -6,7 +6,7 @@ Python bindings through cFFI (API, out-of-line) for calling enry Go functions ex
 
 ```
 $ pushd .. && make static && popd
-$ pip install -r requirments.txt
+$ pip install -r requirements.txt
 $ python build_enry.py
 ```
 


### PR DESCRIPTION
File is named requirements.txt, not requirments.txt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/go-enry/go-enry/38)
<!-- Reviewable:end -->
