### PR TITLE
Fixed GetLanguagesByShebang for paths with “env”

### DIFF
--- a/common.go
+++ b/common.go
@@ -3,6 +3,7 @@ package enry
 import (
 	"bufio"
 	"bytes"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -314,13 +315,17 @@ func getInterpreter(data []byte) (interpreter string) {
 		return ""
 	}
 
-	if bytes.Contains(splitted[0], []byte("env")) {
-		if len(splitted) > 1 {
-			interpreter = string(splitted[1])
+	// Extract interpreter name from path. Use path.Base because
+	// shebang on Cygwin/Windows still use a forward slash
+	interpreter = path.Base(string(splitted[0]))
+
+	// #!/usr/bin/env [...]
+	if interpreter == "env" {
+		if len(splitted) == 1 {
+			// /usr/bin/env with no arguments
+			return ""
 		}
-	} else {
-		splittedPath := bytes.Split(splitted[0], []byte{'/'})
-		interpreter = string(splittedPath[len(splittedPath)-1])
+		interpreter = path.Base(string(splitted[1]))
 	}
 
 	if interpreter == "sh" {

--- a/common_test.go
+++ b/common_test.go
@@ -296,7 +296,8 @@ println("The shell script says ",vm.arglist.concat(" "));`
 		{name: "TestGetLanguagesByShebang_8", content: []byte(`#!bash`), expected: []string{"Shell"}},
 		{name: "TestGetLanguagesByShebang_9", content: []byte(multilineExecHack), expected: []string{"Tcl"}},
 		{name: "TestGetLanguagesByShebang_10", content: []byte(multilineNoExecHack), expected: []string{"Shell"}},
-		{name: "TestGetLanguagesByShebang_11", content: []byte(`#!`), expected: nil},
+		{name: "TestGetLanguagesByShebang_11", content: []byte(`#!/envinpath/python`), expected: []string{"Python"}},
+		{name: "TestGetLanguagesByShebang_12", content: []byte(`#!`), expected: nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Shebang detection fails when the executable path contains the string "env", for example `#!/home/env/bin/python`. This fix aligns `getInterpreter` to closer match `Linguist::Shebang.interpreter` implementation.