### PR TITLE
GitHub Actions workflow to automatically update Linguist

### DIFF
--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -12,7 +12,7 @@ jobs:
       run: |
         set -euo pipefail
         IFS=$'\n\t'        
-        branch_name=$(feature/sync-linguist-$(date +%s))
+        branch_name=feature/sync-linguist-$(date +%s)
         git checkout -b $branch_name
         echo "::set-output name=branch_name::$branch_name"
     - uses: actions/checkout@v2

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -11,7 +11,7 @@ jobs:
       id: branch
       run: |
         set -euo pipefail
-        IFS=$'\n\t'        
+        IFS=$'\n\t'     
         branch_name=feature/sync-linguist-$(date +%s)
         git checkout -b $branch_name
         echo "::set-output name=branch_name::$branch_name"
@@ -32,6 +32,11 @@ jobs:
                     grep -v "-" | \ 
                     sort --version-sort --reverse | \
                     head -1)
+        if [[ $? -ne 0 ]]; then
+          echo "Could not find latest tagged Linguist version"
+          exit 1
+        fi
+
         echo "::set-output name=linguist_version::$latest"
         git checkout $latest
         cd ..

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -1,0 +1,58 @@
+name: Sync Linguist
+on: workflow_dispatch
+
+jobs:
+  sync-linguist:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v2
+    - name: Create a branch
+      run: git checkout -b feature/sync-linguist-$(date +%s)
+    - uses: actions/checkout@v2
+      with:
+        repository: github/linguist
+        path: .linguist
+        fetch-depth: 0
+    - name: check out latest release
+      id: linguist-release
+      run: |
+        set -e
+        cd .linguist
+        $latest=$(git tag --list | \
+                    grep -v "-" | \ # exclude any pre-release versions
+                    sort --version-sort --reverse | \
+                    head -1)
+        echo "::set-output name=linguist_version::$latest"
+        git checkout $latest
+        cd ..
+    - name: Generate code
+      run: make code-generate
+    - name: Commit changes
+      id: commit
+      run: |
+        set -e
+        if [[ -n "$(git status --porcelain)" ]]; then
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m "Updated Linguist to ${{ steps.linguist-release.outputs.linguist_version }}"
+          git push
+          echo "::set-output name=needs_pr::true"
+        else
+          echo "::set-output name=needs_pr::false"
+        fi
+    - name: Create Pull Request
+      id: open-pr
+      uses: repo-sync/pull-request@v2
+      if: ${{ steps.commit.needs_pr == 'true' }}
+      with:
+        destination_branch: "master"
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: output-url
+      if: ${{ steps.commit.needs_pr == 'true' }}
+      run: echo ${{ steps.open-pr.outputs.pr_url }}
+    - name: No PR Created
+      if: ${{ steps.commit.needs_pr == 'false' }}
+      run: echo "No changes for ${{ steps.linguist-release.outputs.linguist_version }}"
+      

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
     - uses: actions/setup-go@v2
     - uses: actions/checkout@v2
+    - name: Find previous Linguist commit
+      id: previous_linguist
+      run: |
+        set -euo pipefail
+        IFS=$'\n\t'
+        commit=$(sed --quiet --regexp-extended 's/[[:space:]]+commit[[:space:]]+=[[:space:]]"([a-f0-9]{40})"/\1/p' internal/code-generator/generator/generator_test.go)
+        echo "::set-output name=commit::$commit"
     - name: Create a branch
       id: branch
       run: |
@@ -98,7 +105,13 @@ jobs:
       with:
         source_branch: ${{ steps.branch.outputs.branch_name }}
         pr_title: "Update Linguist to ${{ steps.linguist-release.outputs.linguist_version }}"
-        pr_body: "Automated Linguist update :robot:"
+        pr_body: |
+          Automated Linguist update :robot:
+
+          This PR updates Linguist from [${{ steps.previous_linguist.outputs.commit }}](https://github.com/github/linguist/commit/${{ steps.previous_linguist.outputs.commit }}) to [${{ steps.linguist-release.outputs.linguist_version }}](https://github.com/github/linguist/releases/tag/${{  steps.linguist-release.outputs.linguist_version }}) ([${{ steps.linguist-release.outputs.linguist_commit }}](https://github.com/github/linguist/commit/${{ steps.linguist-release.outputs.linguist_commit }}))
+
+          * [Linguist release notes](https://github.com/github/linguist/releases/tag/${{ steps.linguist-release.outputs.linguist_version }}
+          * [Compare Linguist code changes](https://github.com/github/linguist/compare/${{ steps.previous_linguist.outputs.commit }}...${{ steps.linguist-release.outputs.linguist_version }})
         destination_branch: "master"
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: output-url

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -80,6 +80,8 @@ jobs:
       uses: repo-sync/pull-request@v2
       if: ${{ steps.commit.outputs.needs_pr == 'true' }}
       with:
+        source_branch: ${{ steps.branch.outputs.branch_name }}
+        pr_body: "Automated Linguist update :robot:"
         destination_branch: "master"
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: output-url

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -46,16 +46,22 @@ jobs:
       run: |
         set -euo pipefail
         IFS=$'\n\t'
+        echo "git current state:"
+        git status
+
         if [[ -n "$(git status --porcelain)" ]]; then
+          echo "Creating Linguist update commit"
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
           git commit -m "Updated Linguist to ${{ steps.linguist-release.outputs.linguist_version }}"
           git push --set-upstream origin ${{ steps.branch.outputs.branch_name }}
           echo "::set-output name=needs_pr::true"
-        else
-          echo "::set-output name=needs_pr::false"
+          exit 0
         fi
+          
+        echo "Linguist update unncessary"
+        echo "::set-output name=needs_pr::false"
     - name: Create Pull Request
       id: open-pr
       uses: repo-sync/pull-request@v2
@@ -67,6 +73,6 @@ jobs:
       if: ${{ steps.commit.needs_pr == 'true' }}
       run: echo ${{ steps.open-pr.outputs.pr_url }}
     - name: No PR Created
-      if: ${{ steps.commit.needs_pr == 'false' }}
+      if: ${{ steps.commit.needs_pr != 'true' }}
       run: echo "No changes for ${{ steps.linguist-release.outputs.linguist_version }}"
       

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -110,7 +110,7 @@ jobs:
         pr_body: |
           Automated Linguist update :robot:
 
-          This PR updates Linguist from `[${{ steps.previous_linguist.outputs.short_commit }}](https://github.com/github/linguist/commit/${{ steps.previous_linguist.outputs.commit }})` to [${{ steps.linguist-release.outputs.linguist_version }}](https://github.com/github/linguist/releases/tag/${{  steps.linguist-release.outputs.linguist_version }}) (`[${{ steps.linguist-release.outputs.short_commit }}](https://github.com/github/linguist/commit/${{ steps.linguist-release.outputs.commit }})`)
+          This PR updates Linguist from [${{ steps.previous_linguist.outputs.short_commit }}](https://github.com/github/linguist/commit/${{ steps.previous_linguist.outputs.commit }}) to [${{ steps.linguist-release.outputs.linguist_version }}](https://github.com/github/linguist/releases/tag/${{  steps.linguist-release.outputs.linguist_version }}) ([${{ steps.linguist-release.outputs.short_commit }}](https://github.com/github/linguist/commit/${{ steps.linguist-release.outputs.commit }}))
 
           * [Linguist release notes](https://github.com/github/linguist/releases/tag/${{ steps.linguist-release.outputs.linguist_version }})
           * [Compare Linguist code changes](https://github.com/github/linguist/compare/${{ steps.previous_linguist.outputs.commit }}...${{ steps.linguist-release.outputs.linguist_version }})

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -90,4 +90,3 @@ jobs:
     - name: No PR Created
       if: ${{ steps.commit.needs_pr != true }}
       run: echo "No changes for ${{ steps.linguist-release.outputs.linguist_version }}"
-      

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -68,6 +68,7 @@ jobs:
           git add .
           git commit -m "Updated Linguist to ${{ steps.linguist-release.outputs.linguist_version }}"
           git push --set-upstream origin ${{ steps.branch.outputs.branch_name }}
+          echo "Changes committed. Will create PR."
           echo "::set-output name=needs_pr::true"
           exit 0
         fi
@@ -77,14 +78,14 @@ jobs:
     - name: Create Pull Request
       id: open-pr
       uses: repo-sync/pull-request@v2
-      if: ${{ steps.commit.needs_pr == 'true' }}
+      if: ${{ steps.commit.needs_pr == true }}
       with:
         destination_branch: "master"
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: output-url
-      if: ${{ steps.commit.needs_pr == 'true' }}
+      if: ${{ steps.commit.needs_pr == true }}
       run: echo ${{ steps.open-pr.outputs.pr_url }}
     - name: No PR Created
-      if: ${{ steps.commit.needs_pr != 'true' }}
+      if: ${{ steps.commit.needs_pr != true }}
       run: echo "No changes for ${{ steps.linguist-release.outputs.linguist_version }}"
       

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         set -e
         cd .linguist
-        $latest=$(git tag --list | \
+        latest=$(git tag --list | \
                     grep -v "-" | \ 
                     sort --version-sort --reverse | \
                     head -1)

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -6,6 +6,9 @@ on:
         description: 'Linguist tag override'
         required: False
         default: ''
+  schedule:
+    # Run once a day to check for new Linguist updates automatically
+    - cron:  '0 20 * * *'
 
 jobs:
   sync-linguist:

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -32,7 +32,7 @@ jobs:
                     grep -v "-" | \
                     sort --version-sort --reverse | \
                     head -1)
-        if [[ -n $latest ]]; then
+        if [[ -z $latest ]]; then
           echo "could not determine latest Linguist version"
           exit 1
         fi

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -1,5 +1,11 @@
 name: Sync Linguist
-on: workflow_dispatch
+on: 
+  workflow_dispatch:
+    inputs:
+      linguist_tag:
+        description: 'Linguist tag override'
+        required: False
+        default: ''
 
 jobs:
   sync-linguist:
@@ -28,10 +34,16 @@ jobs:
         set -euo pipefail
         IFS=$'\n\t'        
         cd .linguist
-        latest=$(git tag --list | \
-                    grep -v "-" | \
-                    sort --version-sort --reverse | \
-                    head -1)
+        if [[ -n "${{ github.event.inputs.linguist_tag }}" ]]; then
+          echo "Using tag override '${{ github.event.inputs.linguist_tag }}'"
+          latest="${{ github.event.inputs.linguist_tag }}"
+        else
+          latest=$(git tag --list | \
+                     grep -v "-" | \
+                     sort --version-sort --reverse | \
+                     head -1)
+        fi
+
         if [[ -z $latest ]]; then
           echo "could not determine latest Linguist version"
           exit 1

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -69,13 +69,13 @@ jobs:
           exit 1
         fi
 
-        echo "::set-output name=linguist_commit::$commit"
-        echo "::set-output name=short_linguist_commit::${commit::8}"
+        echo "::set-output name=commit::$commit"
+        echo "::set-output name=short_commit::${commit::8}"
 
         cd ..
     - name: Update Linguist commit
       run: |
-        sed --in-place --regexp-extended 's/(commit[[:space:]]+=[[:space:]])("[a-f0-9]{40}")/\1"${{ steps.linguist-release.outputs.linguist_commit }}"/' internal/code-generator/generator/generator_test.go
+        sed --in-place --regexp-extended 's/(commit[[:space:]]+=[[:space:]])("[a-f0-9]{40}")/\1"${{ steps.linguist-release.outputs.commit }}"/' internal/code-generator/generator/generator_test.go
     - name: Generate code
       run: make code-generate
     - name: Commit changes
@@ -110,7 +110,7 @@ jobs:
         pr_body: |
           Automated Linguist update :robot:
 
-          This PR updates Linguist from `[${{ steps.previous_linguist.outputs.short_commit }}](https://github.com/github/linguist/commit/${{ steps.previous_linguist.outputs.commit }})` to [${{ steps.linguist-release.outputs.linguist_version }}](https://github.com/github/linguist/releases/tag/${{  steps.linguist-release.outputs.linguist_version }}) (`[${{ steps.linguist-release.outputs.short_linguist_commit }}](https://github.com/github/linguist/commit/${{ steps.linguist-release.outputs.linguist_commit }})`)
+          This PR updates Linguist from `[${{ steps.previous_linguist.outputs.short_commit }}](https://github.com/github/linguist/commit/${{ steps.previous_linguist.outputs.commit }})` to [${{ steps.linguist-release.outputs.linguist_version }}](https://github.com/github/linguist/releases/tag/${{  steps.linguist-release.outputs.linguist_version }}) (`[${{ steps.linguist-release.outputs.short_commit }}](https://github.com/github/linguist/commit/${{ steps.linguist-release.outputs.commit }})`)
 
           * [Linguist release notes](https://github.com/github/linguist/releases/tag/${{ steps.linguist-release.outputs.linguist_version }})
           * [Compare Linguist code changes](https://github.com/github/linguist/compare/${{ steps.previous_linguist.outputs.commit }}...${{ steps.linguist-release.outputs.linguist_version }})

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -110,7 +110,7 @@ jobs:
 
           This PR updates Linguist from [${{ steps.previous_linguist.outputs.commit }}](https://github.com/github/linguist/commit/${{ steps.previous_linguist.outputs.commit }}) to [${{ steps.linguist-release.outputs.linguist_version }}](https://github.com/github/linguist/releases/tag/${{  steps.linguist-release.outputs.linguist_version }}) ([${{ steps.linguist-release.outputs.linguist_commit }}](https://github.com/github/linguist/commit/${{ steps.linguist-release.outputs.linguist_commit }}))
 
-          * [Linguist release notes](https://github.com/github/linguist/releases/tag/${{ steps.linguist-release.outputs.linguist_version }}
+          * [Linguist release notes](https://github.com/github/linguist/releases/tag/${{ steps.linguist-release.outputs.linguist_version }})
           * [Compare Linguist code changes](https://github.com/github/linguist/compare/${{ steps.previous_linguist.outputs.commit }}...${{ steps.linguist-release.outputs.linguist_version }})
         destination_branch: "master"
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -84,6 +84,7 @@ jobs:
       if: ${{ steps.commit.outputs.needs_pr == 'true' }}
       with:
         source_branch: ${{ steps.branch.outputs.branch_name }}
+        pr_title: "Update Linguist to ${{ steps.linguist-release.outputs.linguist_version }}"
         pr_body: "Automated Linguist update :robot:"
         destination_branch: "master"
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -16,11 +16,13 @@ jobs:
         fetch-depth: 0
     - name: check out latest release
       id: linguist-release
+      # the `grep -v "-"` is to exclude any pre-release versions.
+      # Linguist doesn't have any right now, but just in case.
       run: |
         set -e
         cd .linguist
         $latest=$(git tag --list | \
-                    grep -v "-" | \ # exclude any pre-release versions
+                    grep -v "-" | \ 
                     sort --version-sort --reverse | \
                     head -1)
         echo "::set-output name=linguist_version::$latest"

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -23,6 +23,7 @@ jobs:
         IFS=$'\n\t'
         commit=$(sed --quiet --regexp-extended 's/[[:space:]]+commit[[:space:]]+=[[:space:]]"([a-f0-9]{40})"/\1/p' internal/code-generator/generator/generator_test.go)
         echo "::set-output name=commit::$commit"
+        echo "::set-output name=short_commit::${commit::8}"
     - name: Create a branch
       id: branch
       run: |
@@ -69,6 +70,7 @@ jobs:
         fi
 
         echo "::set-output name=linguist_commit::$commit"
+        echo "::set-output name=short_linguist_commit::${commit::8}"
 
         cd ..
     - name: Update Linguist commit
@@ -108,7 +110,7 @@ jobs:
         pr_body: |
           Automated Linguist update :robot:
 
-          This PR updates Linguist from [${{ steps.previous_linguist.outputs.commit }}](https://github.com/github/linguist/commit/${{ steps.previous_linguist.outputs.commit }}) to [${{ steps.linguist-release.outputs.linguist_version }}](https://github.com/github/linguist/releases/tag/${{  steps.linguist-release.outputs.linguist_version }}) ([${{ steps.linguist-release.outputs.linguist_commit }}](https://github.com/github/linguist/commit/${{ steps.linguist-release.outputs.linguist_commit }}))
+          This PR updates Linguist from `[${{ steps.previous_linguist.outputs.short_commit }}](https://github.com/github/linguist/commit/${{ steps.previous_linguist.outputs.commit }})` to [${{ steps.linguist-release.outputs.linguist_version }}](https://github.com/github/linguist/releases/tag/${{  steps.linguist-release.outputs.linguist_version }}) (`[${{ steps.linguist-release.outputs.short_linguist_commit }}](https://github.com/github/linguist/commit/${{ steps.linguist-release.outputs.linguist_commit }})`)
 
           * [Linguist release notes](https://github.com/github/linguist/releases/tag/${{ steps.linguist-release.outputs.linguist_version }})
           * [Compare Linguist code changes](https://github.com/github/linguist/compare/${{ steps.previous_linguist.outputs.commit }}...${{ steps.linguist-release.outputs.linguist_version }})

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -47,13 +47,26 @@ jobs:
                      head -1)
         fi
 
-        if [[ -z $latest ]]; then
+        if [[ -z "$latest" ]]; then
           echo "could not determine latest Linguist version"
           exit 1
         fi
+
         echo "::set-output name=linguist_version::$latest"
         git checkout $latest
+      
+        commit=$(git rev-parse HEAD)
+        if [[ -z "$commit" ]]; then
+          echo "could not determine latest Linguist commit"
+          exit 1
+        fi
+
+        echo "::set-output name=linguist_commit::$commit"
+
         cd ..
+    - name: Update Linguist commit
+      run: |
+        sed --in-place --regexp-extended 's/(commit[[:space:]]+=[[:space:]])("[a-f0-9]{40}")/\1"${{ steps.linguist-release.outputs.linguist_commit }}"/' internal/code-generator/generator/generator_test.go
     - name: Generate code
       run: make code-generate
     - name: Commit changes

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -78,12 +78,12 @@ jobs:
     - name: Create Pull Request
       id: open-pr
       uses: repo-sync/pull-request@v2
-      if: ${{ steps.commit.needs_pr == true }}
+      if: ${{ steps.commit.outputs.needs_pr == 'true' }}
       with:
         destination_branch: "master"
         github_token: ${{ secrets.GITHUB_TOKEN }}
     - name: output-url
-      if: ${{ steps.commit.needs_pr == true }}
+      if: ${{ steps.commit.outputs.needs_pr == 'true' }}
       run: echo ${{ steps.open-pr.outputs.pr_url }}
     - name: No PR Created
       if: ${{ steps.commit.needs_pr != true }}

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -29,14 +29,13 @@ jobs:
         IFS=$'\n\t'        
         cd .linguist
         latest=$(git tag --list | \
-                    grep -v "-" | \ 
+                    grep -v "-" | \
                     sort --version-sort --reverse | \
                     head -1)
-        if [[ $? -ne 0 ]]; then
-          echo "Could not find latest tagged Linguist version"
+        if [[ -n $latest ]]; then
+          echo "could not determine latest Linguist version"
           exit 1
         fi
-
         echo "::set-output name=linguist_version::$latest"
         git checkout $latest
         cd ..

--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -8,7 +8,13 @@ jobs:
     - uses: actions/setup-go@v2
     - uses: actions/checkout@v2
     - name: Create a branch
-      run: git checkout -b feature/sync-linguist-$(date +%s)
+      id: branch
+      run: |
+        set -euo pipefail
+        IFS=$'\n\t'        
+        branch_name=$(feature/sync-linguist-$(date +%s))
+        git checkout -b $branch_name
+        echo "::set-output name=branch_name::$branch_name"
     - uses: actions/checkout@v2
       with:
         repository: github/linguist
@@ -19,7 +25,8 @@ jobs:
       # the `grep -v "-"` is to exclude any pre-release versions.
       # Linguist doesn't have any right now, but just in case.
       run: |
-        set -e
+        set -euo pipefail
+        IFS=$'\n\t'        
         cd .linguist
         latest=$(git tag --list | \
                     grep -v "-" | \ 
@@ -33,13 +40,14 @@ jobs:
     - name: Commit changes
       id: commit
       run: |
-        set -e
+        set -euo pipefail
+        IFS=$'\n\t'
         if [[ -n "$(git status --porcelain)" ]]; then
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .
           git commit -m "Updated Linguist to ${{ steps.linguist-release.outputs.linguist_version }}"
-          git push
+          git push --set-upstream origin ${{ steps.branch.outputs.branch_name }}
           echo "::set-output name=needs_pr::true"
         else
           echo "::set-output name=needs_pr::false"


### PR DESCRIPTION
This adds a GitHub Actions workflow that performs the steps necessary to update Linguist to the latest release tag and creates a PR.

You can see an example of [such a PR in my fork](https://github.com/look/go-enry/pull/3) (it also includes the commits from this PR, but that won't happen in your repo once this is merged).

I've included a `workflow_dispatch` trigger with an override for the Linguist tag, so you can test it out. In order to test it, the workflow file needs to exist on `master`, but once it does you can pick a branch and run the workflow from there. The Linguist tag is optional, but allows you to test updating the generated code when Linguist hasn't changed.

<img width="462" alt="Screen Shot 2021-10-08 at 4 17 38 PM" src="https://user-images.githubusercontent.com/10186/136633875-4ebf634e-3eb6-4d51-b007-647105eacfe3.png">

I also included a schedule to trigger the workflow once a day. That will start running once the workflow is on `master`, but I haven't been able to test if it works yet. If not, likely it will require a small tweak to add an explicit secret.

Hopefully this reduces the maintenance overhead of keeping go-enry up-to-date with Linguist releases! 🙇 

Closes #51 