### PR TITLE
support for incompatible heuristics using oniguruma

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The `enry` library is based on the data from `github/linguist` version **v7.16.1
 
 Parsing [linguist/samples](https://github.com/github/linguist/tree/master/samples) the following `enry` results are different from the Linguist:
 
-- [Heuristics for ".txt" extension](https://github.com/github/linguist/blob/8083cb5a89cee2d99f5a988f165994d0243f0d1e/lib/linguist/heuristics.yml#L521) in Vim Help File could not be parsed, due to unsupported negative lookahead in RE2 regexp engine.
+- [Heuristics for ".txt" extension](https://github.com/github/linguist/blob/8083cb5a89cee2d99f5a988f165994d0243f0d1e/lib/linguist/heuristics.yml#L521) in Vim Help File could not be parsed, due to unsupported negative lookahead in RE2 regexp engine. 
 
 - [Heuristics for ".sol" extension](https://github.com/github/linguist/blob/8083cb5a89cee2d99f5a988f165994d0243f0d1e/lib/linguist/heuristics.yml#L464) in Solidity could not be parsed, due to unsupported negative lookahead in RE2 regexp engine.
 
@@ -181,6 +181,8 @@ Parsing [linguist/samples](https://github.com/github/linguist/tree/master/sample
 - `enry` CLI output does NOT exclude `.gitignore`ed files and git submodules, as Linguist does
 
 In all the cases above that have an issue number - we plan to update enry to match Linguist behavior.
+
+> All the heuristics issues related to the regexp's incompatibilities can be avoided using the `oniguruma` support. 
 
 ## Benchmarks
 

--- a/data/content.go
+++ b/data/content.go
@@ -4,9 +4,8 @@
 package data
 
 import (
-	"regexp"
-
 	"github.com/go-enry/go-enry/v2/data/rule"
+	"github.com/go-enry/go-enry/v2/regex"
 )
 
 var ContentHeuristics = map[string]*Heuristics{
@@ -15,31 +14,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".1in": &Heuristics{
@@ -47,26 +46,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -78,26 +77,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -109,26 +108,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -140,31 +139,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".3": &Heuristics{
@@ -172,31 +171,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".3in": &Heuristics{
@@ -204,26 +203,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -235,26 +234,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -266,26 +265,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -297,26 +296,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -328,26 +327,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -359,26 +358,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -390,31 +389,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".5": &Heuristics{
@@ -422,31 +421,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".6": &Heuristics{
@@ -454,31 +453,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".7": &Heuristics{
@@ -486,31 +485,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".8": &Heuristics{
@@ -518,31 +517,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".9": &Heuristics{
@@ -550,31 +549,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".al": &Heuristics{
@@ -582,38 +581,43 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("AL"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)\b(?i:(CODEUNIT|PAGE|PAGEEXTENSION|PAGECUSTOMIZATION|DOTNET|ENUM|ENUMEXTENSION|VALUE|QUERY|REPORT|TABLE|TABLEEXTENSION|XMLPORT|PROFILE|CONTROLADDIN))\b`),
+				regex.MustCompileRuby(`\b(?i:(CODEUNIT|PAGE|PAGEEXTENSION|PAGECUSTOMIZATION|DOTNET|ENUM|ENUMEXTENSION|VALUE|QUERY|REPORT|TABLE|TABLEEXTENSION|XMLPORT|PROFILE|CONTROLADDIN))\b`),
 			),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Perl"),
 		),
 	},
-	".as": &Heuristics{},
+	".as": &Heuristics{
+		rule.Or(
+			rule.MatchingLanguages("ActionScript"),
+			regex.MustCompileRuby(`^\s*(?:package(?:\s+[\w.]+)?\s+(?:{|$)|import\s+[\w.*]+\s*;|(?=.*?(?:intrinsic|extends))(intrinsic\s+)?class\s+[\w<>.]+(?:\s+extends\s+[\w<>.]+)?|(?:(?:public|protected|private|static)\s+)*(?:(?:var|const|local)\s+\w+\s*:\s*[\w<>.]+(?:\s*=.*)?\s*;|function\s+\w+\s*\((?:\s*\w+\s*:\s*[\w<>.]+\s*(,\s*\w+\s*:\s*[\w<>.]+\s*)*)?\)))`),
+		),
+	},
 	".asc": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Public Key"),
-			regexp.MustCompile(`(?m)^(----[- ]BEGIN|ssh-(rsa|dss)) `),
+			regex.MustCompileRuby(`^(----[- ]BEGIN|ssh-(rsa|dss)) `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("AsciiDoc"),
-			regexp.MustCompile(`(?m)^[=-]+(\s|\n)|{{[A-Za-z]`),
+			regex.MustCompileRuby(`^[=-]+(\s|\n)|{{[A-Za-z]`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("AGS Script"),
-			regexp.MustCompile(`(?m)^(\/\/.+|((import|export)\s+)?(function|int|float|char)\s+((room|repeatedly|on|game)_)?([A-Za-z]+[A-Za-z_0-9]+)\s*[;\(])`),
+			regex.MustCompileRuby(`^(\/\/.+|((import|export)\s+)?(function|int|float|char)\s+((room|repeatedly|on|game)_)?([A-Za-z]+[A-Za-z_0-9]+)\s*[;\(])`),
 		),
 	},
 	".asm": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Motorola 68K Assembly"),
-			regexp.MustCompile(`(?m)(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
+			regex.MustCompileRuby(`(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
 		),
 	},
 	".asy": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("LTspice Symbol"),
-			regexp.MustCompile(`(?m)^SymbolType[ \t]`),
+			regex.MustCompileRuby(`^SymbolType[ \t]`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Asymptote"),
@@ -622,163 +626,167 @@ var ContentHeuristics = map[string]*Heuristics{
 	".bas": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("FreeBasic"),
-			regexp.MustCompile(`(?m)^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s`),
+			regex.MustCompileRuby(`^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("BASIC"),
-			regexp.MustCompile(`(?m)^\s*\d+`),
+			regex.MustCompileRuby(`^\s*\d+`),
 		),
 	},
 	".bb": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("BlitzBasic"),
-			regexp.MustCompile(`(?m)(<^\s*; |End Function)`),
+			regex.MustCompileRuby(`(<^\s*; |End Function)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("BitBake"),
-			regexp.MustCompile(`(?m)^\s*(# |include|require)\b`),
+			regex.MustCompileRuby(`^\s*(# |include|require)\b`),
 		),
 	},
 	".bi": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("FreeBasic"),
-			regexp.MustCompile(`(?m)^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s`),
+			regex.MustCompileRuby(`^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s`),
 		),
 	},
 	".builds": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)^(\s*)(?i:<Project|<Import|<Property|<?xml|xmlns)`),
+			regex.MustCompileRuby(`^(\s*)(?i:<Project|<Import|<Property|<?xml|xmlns)`),
 		),
 	},
 	".ch": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("xBase"),
-			regexp.MustCompile(`(?m)^\s*#\s*(?i:if|ifdef|ifndef|define|command|xcommand|translate|xtranslate|include|pragma|undef)\b`),
+			regex.MustCompileRuby(`^\s*#\s*(?i:if|ifdef|ifndef|define|command|xcommand|translate|xtranslate|include|pragma|undef)\b`),
 		),
 	},
 	".cl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Common Lisp"),
-			regexp.MustCompile(`(?m)^\s*\((?i:defun|in-package|defpackage) `),
+			regex.MustCompileRuby(`^\s*\((?i:defun|in-package|defpackage) `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Cool"),
-			regexp.MustCompile(`(?m)^class`),
+			regex.MustCompileRuby(`^class`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("OpenCL"),
-			regexp.MustCompile(`(?m)\/\* |\/\/ |^\}`),
+			regex.MustCompileRuby(`\/\* |\/\/ |^\}`),
 		),
 	},
 	".cls": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("TeX"),
-			regexp.MustCompile(`(?m)^\s*\\(?:NeedsTeXFormat|ProvidesClass){`),
+			regex.MustCompileRuby(`^\s*\\(?:NeedsTeXFormat|ProvidesClass){`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("ObjectScript"),
-			regexp.MustCompile(`(?m)^Class\s`),
+			regex.MustCompileRuby(`^Class\s`),
 		),
 	},
 	".cmp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Gerber Image"),
-			regexp.MustCompile(`(?m)^[DGMT][0-9]{2}\*\r?\n`),
+			regex.MustCompileRuby(`^[DGMT][0-9]{2}\*\r?\n`),
 		),
 	},
 	".cs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Smalltalk"),
-			regexp.MustCompile(`(?m)![\w\s]+methodsFor: `),
+			regex.MustCompileRuby(`![\w\s]+methodsFor: `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("C#"),
-			regexp.MustCompile(`(?m)^(\s*namespace\s*[\w\.]+\s*{|\s*\/\/)`),
+			regex.MustCompileRuby(`^(\s*namespace\s*[\w\.]+\s*{|\s*\/\/)`),
 		),
 	},
 	".csl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)(?i:^\s*(\<\?xml|xmlns))`),
+			regex.MustCompileRuby(`(?i:^\s*(\<\?xml|xmlns))`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Kusto"),
-			regexp.MustCompile(`(?m)(^\|\s*(where|extend|project|limit|summarize))|(^\.\w+)`),
+			regex.MustCompileRuby(`(^\|\s*(where|extend|project|limit|summarize))|(^\.\w+)`),
 		),
 	},
 	".d": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("D"),
-			regexp.MustCompile(`(?m)^module\s+[\w.]*\s*;|import\s+[\w\s,.:]*;|\w+\s+\w+\s*\(.*\)(?:\(.*\))?\s*{[^}]*}|unittest\s*(?:\(.*\))?\s*{[^}]*}`),
+			regex.MustCompileRuby(`^module\s+[\w.]*\s*;|import\s+[\w\s,.:]*;|\w+\s+\w+\s*\(.*\)(?:\(.*\))?\s*{[^}]*}|unittest\s*(?:\(.*\))?\s*{[^}]*}`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("DTrace"),
-			regexp.MustCompile(`(?m)^(\w+:\w*:\w*:\w*|BEGIN|END|provider\s+|(tick|profile)-\w+\s+{[^}]*}|#pragma\s+D\s+(option|attributes|depends_on)\s|#pragma\s+ident\s)`),
+			regex.MustCompileRuby(`^(\w+:\w*:\w*:\w*|BEGIN|END|provider\s+|(tick|profile)-\w+\s+{[^}]*}|#pragma\s+D\s+(option|attributes|depends_on)\s|#pragma\s+ident\s)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Makefile"),
-			regexp.MustCompile(`(?m)([\/\\].*:\s+.*\s\\$|: \\$|^[ %]:|^[\w\s\/\\.]+\w+\.\w+\s*:\s+[\w\s\/\\.]+\w+\.\w+)`),
+			regex.MustCompileRuby(`([\/\\].*:\s+.*\s\\$|: \\$|^[ %]:|^[\w\s\/\\.]+\w+\.\w+\s*:\s+[\w\s\/\\.]+\w+\.\w+)`),
 		),
 	},
 	".dsp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Microsoft Developer Studio Project"),
-			regexp.MustCompile(`(?m)# Microsoft Developer Studio Generated Build File`),
+			regex.MustCompileRuby(`# Microsoft Developer Studio Generated Build File`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Faust"),
-			regexp.MustCompile(`(?m)\bprocess\s*[(=]|\b(library|import)\s*\(\s*"|\bdeclare\s+(name|version|author|copyright|license)\s+"`),
+			regex.MustCompileRuby(`\bprocess\s*[(=]|\b(library|import)\s*\(\s*"|\bdeclare\s+(name|version|author|copyright|license)\s+"`),
 		),
 	},
 	".ecl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("ECLiPSe"),
-			regexp.MustCompile(`(?m)^[^#]+:-`),
+			regex.MustCompileRuby(`^[^#]+:-`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("ECL"),
-			regexp.MustCompile(`(?m):=`),
+			regex.MustCompileRuby(`:=`),
 		),
 	},
 	".es": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Erlang"),
-			regexp.MustCompile(`(?m)^\s*(?:%%|main\s*\(.*?\)\s*->)`),
+			regex.MustCompileRuby(`^\s*(?:%%|main\s*\(.*?\)\s*->)`),
+		),
+		rule.Or(
+			rule.MatchingLanguages("JavaScript"),
+			regex.MustCompileRuby(`(?m:\/\/|("|')use strict\1|export\s+default\s|\/\*.*?\*\/)`),
 		),
 	},
 	".f": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Forth"),
-			regexp.MustCompile(`(?m)^: `),
+			regex.MustCompileRuby(`^: `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Filebench WML"),
-			regexp.MustCompile(`(?m)flowop`),
+			regex.MustCompileRuby(`flowop`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Fortran"),
-			regexp.MustCompile(`(?m)^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)`),
+			regex.MustCompileRuby(`^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)`),
 		),
 	},
 	".for": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Forth"),
-			regexp.MustCompile(`(?m)^: `),
+			regex.MustCompileRuby(`^: `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Fortran"),
-			regexp.MustCompile(`(?m)^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)`),
+			regex.MustCompileRuby(`^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)`),
 		),
 	},
 	".fr": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Forth"),
-			regexp.MustCompile(`(?m)^(: |also |new-device|previous )`),
+			regex.MustCompileRuby(`^(: |also |new-device|previous )`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Frege"),
-			regexp.MustCompile(`(?m)^\s*(import|module|package|data|type) `),
+			regex.MustCompileRuby(`^\s*(import|module|package|data|type) `),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Text"),
@@ -787,49 +795,53 @@ var ContentHeuristics = map[string]*Heuristics{
 	".fs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Forth"),
-			regexp.MustCompile(`(?m)^(: |new-device)`),
+			regex.MustCompileRuby(`^(: |new-device)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("F#"),
-			regexp.MustCompile(`(?m)^\s*(#light|import|let|module|namespace|open|type)`),
+			regex.MustCompileRuby(`^\s*(#light|import|let|module|namespace|open|type)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("GLSL"),
-			regexp.MustCompile(`(?m)^\s*(#version|precision|uniform|varying|vec[234])`),
+			regex.MustCompileRuby(`^\s*(#version|precision|uniform|varying|vec[234])`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Filterscript"),
-			regexp.MustCompile(`(?m)#include|#pragma\s+(rs|version)|__attribute__`),
+			regex.MustCompileRuby(`#include|#pragma\s+(rs|version)|__attribute__`),
 		),
 	},
 	".ftl": &Heuristics{
 		rule.Or(
+			rule.MatchingLanguages("FreeMarker"),
+			regex.MustCompileRuby(`^(?:<|[a-zA-Z-][a-zA-Z0-9_-]+[ \t]+\w)|\${\w+[^\n]*?}|^[ \t]*(?:<#--.*?-->|<#([a-z]+)(?=\s|>)[^>]*>.*?</#\1>|\[#--.*?--\]|\[#([a-z]+)(?=\s|\])[^\]]*\].*?\[#\2\])`),
+		),
+		rule.Or(
 			rule.MatchingLanguages("Fluent"),
-			regexp.MustCompile(`(?m)^-?[a-zA-Z][a-zA-Z0-9_-]* *=|\{\$-?[a-zA-Z][-\w]*(?:\.[a-zA-Z][-\w]*)?\}`),
+			regex.MustCompileRuby(`^-?[a-zA-Z][a-zA-Z0-9_-]* *=|\{\$-?[a-zA-Z][-\w]*(?:\.[a-zA-Z][-\w]*)?\}`),
 		),
 	},
 	".gd": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("GAP"),
-			regexp.MustCompile(`(?m)\s*(Declare|BindGlobal|KeyDependentOperation)`),
+			regex.MustCompileRuby(`\s*(Declare|BindGlobal|KeyDependentOperation)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("GDScript"),
-			regexp.MustCompile(`(?m)\s*(extends|var|const|enum|func|class|signal|tool|yield|assert|onready)`),
+			regex.MustCompileRuby(`\s*(extends|var|const|enum|func|class|signal|tool|yield|assert|onready)`),
 		),
 	},
 	".gml": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)(?i:^\s*(\<\?xml|xmlns))`),
+			regex.MustCompileRuby(`(?i:^\s*(\<\?xml|xmlns))`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Graph Modeling Language"),
-			regexp.MustCompile(`(?m)(?i:^\s*(graph|node)\s+\[$)`),
+			regex.MustCompileRuby(`(?i:^\s*(graph|node)\s+\[$)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Gerber Image"),
-			regexp.MustCompile(`(?m)^[DGMT][0-9]{2}\*$`),
+			regex.MustCompileRuby(`^[DGMT][0-9]{2}\*$`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Game Maker Language"),
@@ -838,25 +850,25 @@ var ContentHeuristics = map[string]*Heuristics{
 	".gs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("GLSL"),
-			regexp.MustCompile(`(?m)^#version\s+[0-9]+\b`),
+			regex.MustCompileRuby(`^#version\s+[0-9]+\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Gosu"),
-			regexp.MustCompile(`(?m)^uses (java|gw)\.`),
+			regex.MustCompileRuby(`^uses (java|gw)\.`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Genie"),
-			regexp.MustCompile(`(?m)^\[indent=[0-9]+\]`),
+			regex.MustCompileRuby(`^\[indent=[0-9]+\]`),
 		),
 	},
 	".h": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Objective-C"),
-			regexp.MustCompile(`(?m)^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])`),
+			regex.MustCompileRuby(`^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("C++"),
-			regexp.MustCompile(`(?m)^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>|^\s*template\s*<|^[ \t]*(try|constexpr)|^[ \t]*catch\s*\(|^[ \t]*(class|(using[ \t]+)?namespace)\s+\w+|^[ \t]*(private|public|protected):$|std::\w+`),
+			regex.MustCompileRuby(`^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>|^\s*template\s*<|^[ \t]*(try|constexpr)|^[ \t]*catch\s*\(|^[ \t]*(class|(using[ \t]+)?namespace)\s+\w+|^[ \t]*(private|public|protected):$|std::\w+`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("C"),
@@ -865,23 +877,23 @@ var ContentHeuristics = map[string]*Heuristics{
 	".hh": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Hack"),
-			regexp.MustCompile(`(?m)<\?hh`),
+			regex.MustCompileRuby(`<\?hh`),
 		),
 	},
 	".i": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Motorola 68K Assembly"),
-			regexp.MustCompile(`(?m)(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
+			regex.MustCompileRuby(`(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("SWIG"),
-			regexp.MustCompile(`(?m)^[ \t]*%[a-z_]+\b|^%[{}]$`),
+			regex.MustCompileRuby(`^[ \t]*%[a-z_]+\b|^%[{}]$`),
 		),
 	},
 	".ice": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("JSON"),
-			regexp.MustCompile(`(?m)\A\s*[{\[]`),
+			regex.MustCompileRuby(`\A\s*[{\[]`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Slice"),
@@ -890,57 +902,61 @@ var ContentHeuristics = map[string]*Heuristics{
 	".inc": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Motorola 68K Assembly"),
-			regexp.MustCompile(`(?m)(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
+			regex.MustCompileRuby(`(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("PHP"),
-			regexp.MustCompile(`(?m)^<\?(?:php)?`),
+			regex.MustCompileRuby(`^<\?(?:php)?`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("SourcePawn"),
-			regexp.MustCompile(`(?m)^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\)(?:\s*{)?)|^methodmap\s+\w+\s+<\s+\w+|^\s*MarkNativeAsOptional\s*\(`),
+			regex.MustCompileRuby(`^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\)(?:\s*{)?)|^methodmap\s+\w+\s+<\s+\w+|^\s*MarkNativeAsOptional\s*\(`),
+		),
+		rule.Or(
+			rule.MatchingLanguages("NASL"),
+			regex.MustCompileRuby(`^\s*include\s*\(\s*(?:"|')[\\/\w\-\.:\s]+\.(?:nasl|inc)\s*(?:"|')\s*\)\s*;|^\s*(?:global|local)_var\s+(?:\w+(?:\s*=\s*[\w\-"']+)?\s*)(?:,\s*\w+(?:\s*=\s*[\w\-"']+)?\s*)*+\s*;|^\s*namespace\s+\w+\s*{|^\s*object\s+\w+\s*(?:extends\s+\w+(?:::\w+)?)?\s*{|^\s*(?:public\s+|private\s+|\s*)function\s+\w+\s*\([\w\s,]*\)\s*{`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("POV-Ray SDL"),
-			regexp.MustCompile(`(?m)^\s*#(declare|local|macro|while)\s`),
+			regex.MustCompileRuby(`^\s*#(declare|local|macro|while)\s`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Pascal"),
-			regexp.MustCompile(`(?m)(?i:^\s*{\$(?:mode|ifdef|undef|define)[ ]+[a-z0-9_]+})|^\s*end[.;]\s*$`),
+			regex.MustCompileRuby(`(?i:^\s*{\$(?:mode|ifdef|undef|define)[ ]+[a-z0-9_]+})|^\s*end[.;]\s*$`),
 		),
 	},
 	".l": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Common Lisp"),
-			regexp.MustCompile(`(?m)\(def(un|macro)\s`),
+			regex.MustCompileRuby(`\(def(un|macro)\s`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Lex"),
-			regexp.MustCompile(`(?m)^(%[%{}]xs|<.*>)`),
+			regex.MustCompileRuby(`^(%[%{}]xs|<.*>)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.[A-Za-z]{2}(\s|$)`),
+			regex.MustCompileRuby(`^\.[A-Za-z]{2}(\s|$)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("PicoLisp"),
-			regexp.MustCompile(`(?m)^\((de|class|rel|code|data|must)\s`),
+			regex.MustCompileRuby(`^\((de|class|rel|code|data|must)\s`),
 		),
 	},
 	".lisp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Common Lisp"),
-			regexp.MustCompile(`(?m)^\s*\((?i:defun|in-package|defpackage) `),
+			regex.MustCompileRuby(`^\s*\((?i:defun|in-package|defpackage) `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("NewLisp"),
-			regexp.MustCompile(`(?m)^\s*\(define `),
+			regex.MustCompileRuby(`^\s*\(define `),
 		),
 	},
 	".ls": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("LoomScript"),
-			regexp.MustCompile(`(?m)^\s*package\s*[\w\.\/\*\s]*\s*{`),
+			regex.MustCompileRuby(`^\s*package\s*[\w\.\/\*\s]*\s*{`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("LiveScript"),
@@ -949,54 +965,54 @@ var ContentHeuristics = map[string]*Heuristics{
 	".lsp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Common Lisp"),
-			regexp.MustCompile(`(?m)^\s*\((?i:defun|in-package|defpackage) `),
+			regex.MustCompileRuby(`^\s*\((?i:defun|in-package|defpackage) `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("NewLisp"),
-			regexp.MustCompile(`(?m)^\s*\(define `),
+			regex.MustCompileRuby(`^\s*\(define `),
 		),
 	},
 	".m": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Objective-C"),
-			regexp.MustCompile(`(?m)^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])`),
+			regex.MustCompileRuby(`^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Mercury"),
-			regexp.MustCompile(`(?m):- module`),
+			regex.MustCompileRuby(`:- module`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("MUF"),
-			regexp.MustCompile(`(?m)^: `),
+			regex.MustCompileRuby(`^: `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("M"),
-			regexp.MustCompile(`(?m)^\s*;`),
+			regex.MustCompileRuby(`^\s*;`),
 		),
 		rule.And(
 			rule.MatchingLanguages("Mathematica"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)\(\*`),
+				regex.MustCompileRuby(`\(\*`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)\*\)$`),
+				regex.MustCompileRuby(`\*\)$`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("MATLAB"),
-			regexp.MustCompile(`(?m)^\s*%`),
+			regex.MustCompileRuby(`^\s*%`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Limbo"),
-			regexp.MustCompile(`(?m)^\w+\s*:\s*module\s*{`),
+			regex.MustCompileRuby(`^\w+\s*:\s*module\s*{`),
 		),
 	},
 	".m4": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("M4Sugar"),
-			regexp.MustCompile(`(?m)AC_DEFUN|AC_PREREQ|AC_INIT|^_?m4_`),
+			regex.MustCompileRuby(`AC_DEFUN|AC_PREREQ|AC_INIT|^_?m4_`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("M4"),
@@ -1007,26 +1023,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -1036,17 +1052,17 @@ var ContentHeuristics = map[string]*Heuristics{
 	".mask": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Unity3d Asset"),
-			regexp.MustCompile(`(?m)tag:unity3d.com`),
+			regex.MustCompileRuby(`tag:unity3d.com`),
 		),
 	},
 	".md": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Markdown"),
-			regexp.MustCompile(`(?m)(^[-A-Za-z0-9=#!\*\[|>])|<\/|\A\z`),
+			regex.MustCompileRuby(`(^[-A-Za-z0-9=#!\*\[|>])|<\/|\A\z`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("GCC Machine Description"),
-			regexp.MustCompile(`(?m)^(;;|\(define_)`),
+			regex.MustCompileRuby(`^(;;|\(define_)`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Markdown"),
@@ -1057,26 +1073,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -1086,21 +1102,21 @@ var ContentHeuristics = map[string]*Heuristics{
 	".ml": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("OCaml"),
-			regexp.MustCompile(`(?m)(^\s*module)|let rec |match\s+(\S+\s)+with`),
+			regex.MustCompileRuby(`(^\s*module)|let rec |match\s+(\S+\s)+with`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Standard ML"),
-			regexp.MustCompile(`(?m)=> |case\s+(\S+\s)+of`),
+			regex.MustCompileRuby(`=> |case\s+(\S+\s)+of`),
 		),
 	},
 	".mod": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)<!ENTITY `),
+			regex.MustCompileRuby(`<!ENTITY `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Modula-2"),
-			regexp.MustCompile(`(?m)^\s*(?i:MODULE|END) [\w\.]+;`),
+			regex.MustCompileRuby(`^\s*(?i:MODULE|END) [\w\.]+;`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Linux Kernel Module", "AMPL"),
@@ -1109,17 +1125,17 @@ var ContentHeuristics = map[string]*Heuristics{
 	".ms": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^[.'][A-Za-z]{2}(\s|$)`),
+			regex.MustCompileRuby(`^[.'][A-Za-z]{2}(\s|$)`),
 		),
 		rule.And(
 			rule.MatchingLanguages("Unix Assembly"),
 			rule.Not(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)/\*`),
+				regex.MustCompileRuby(`/\*`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^\s*\.(?:include\s|globa?l\s|[A-Za-z][_A-Za-z0-9]*:)`),
+				regex.MustCompileRuby(`^\s*\.(?:include\s|globa?l\s|[A-Za-z][_A-Za-z0-9]*:)`),
 			),
 		),
 		rule.Always(
@@ -1129,31 +1145,31 @@ var ContentHeuristics = map[string]*Heuristics{
 	".n": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^[.']`),
+			regex.MustCompileRuby(`^[.']`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Nemerle"),
-			regexp.MustCompile(`(?m)^(module|namespace|using)\s`),
+			regex.MustCompileRuby(`^(module|namespace|using)\s`),
 		),
 	},
 	".ncl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)^\s*<\?xml\s+version`),
+			regex.MustCompileRuby(`^\s*<\?xml\s+version`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Gerber Image"),
-			regexp.MustCompile(`(?m)^[DGMT][0-9]{2}\*\r?\n`),
+			regex.MustCompileRuby(`^[DGMT][0-9]{2}\*\r?\n`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Text"),
-			regexp.MustCompile(`(?m)THE_TITLE`),
+			regex.MustCompileRuby(`THE_TITLE`),
 		),
 	},
 	".nl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("NL"),
-			regexp.MustCompile(`(?m)^(b|g)[0-9]+ `),
+			regex.MustCompileRuby(`^(b|g)[0-9]+ `),
 		),
 		rule.Always(
 			rule.MatchingLanguages("NewLisp"),
@@ -1162,17 +1178,17 @@ var ContentHeuristics = map[string]*Heuristics{
 	".odin": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Object Data Instance Notation"),
-			regexp.MustCompile(`(?m)(?:^|<)\s*[A-Za-z0-9_]+\s*=\s*<`),
+			regex.MustCompileRuby(`(?:^|<)\s*[A-Za-z0-9_]+\s*=\s*<`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Odin"),
-			regexp.MustCompile(`(?m)package\s+\w+|\b(?:im|ex)port\s*"[\w:./]+"|\w+\s*::\s*(?:proc|struct)\s*\(|^\s*//\s`),
+			regex.MustCompileRuby(`package\s+\w+|\b(?:im|ex)port\s*"[\w:./]+"|\w+\s*::\s*(?:proc|struct)\s*\(|^\s*//\s`),
 		),
 	},
 	".p": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Gnuplot"),
-			regexp.MustCompile(`(?m)^s?plot\b|^set\s+(term|terminal|out|output|[xy]tics|[xy]label|[xy]range|style)\b`),
+			regex.MustCompileRuby(`^s?plot\b|^set\s+(term|terminal|out|output|[xy]tics|[xy]label|[xy]range|style)\b`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("OpenEdge ABL"),
@@ -1181,31 +1197,31 @@ var ContentHeuristics = map[string]*Heuristics{
 	".php": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Hack"),
-			regexp.MustCompile(`(?m)<\?hh`),
+			regex.MustCompileRuby(`<\?hh`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("PHP"),
-			regexp.MustCompile(`(?m)<\?[^h]`),
+			regex.MustCompileRuby(`<\?[^h]`),
 		),
 	},
 	".pl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Prolog"),
-			regexp.MustCompile(`(?m)^[^#]*:-`),
+			regex.MustCompileRuby(`^[^#]*:-`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Perl"),
-			regexp.MustCompile(`(?m)\buse\s+(?:strict\b|v?5\.)`),
+			regex.MustCompileRuby(`\buse\s+(?:strict\b|v?5\.)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Raku"),
-			regexp.MustCompile(`(?m)^\s*(?:use\s+v6\b|\bmodule\b|\b(?:my\s+)?class\b)`),
+			regex.MustCompileRuby(`^\s*(?:use\s+v6\b|\bmodule\b|\b(?:my\s+)?class\b)`),
 		),
 	},
 	".plist": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML Property List"),
-			regexp.MustCompile(`(?m)<!DOCTYPE\s+plist`),
+			regex.MustCompileRuby(`<!DOCTYPE\s+plist`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("OpenStep Property List"),
@@ -1214,21 +1230,21 @@ var ContentHeuristics = map[string]*Heuristics{
 	".pm": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Perl"),
-			regexp.MustCompile(`(?m)\buse\s+(?:strict\b|v?5\.)`),
+			regex.MustCompileRuby(`\buse\s+(?:strict\b|v?5\.)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Raku"),
-			regexp.MustCompile(`(?m)^\s*(?:use\s+v6\b|\bmodule\b|\b(?:my\s+)?class\b)`),
+			regex.MustCompileRuby(`^\s*(?:use\s+v6\b|\bmodule\b|\b(?:my\s+)?class\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("X PixMap"),
-			regexp.MustCompile(`(?m)^\s*\/\* XPM \*\/`),
+			regex.MustCompileRuby(`^\s*\/\* XPM \*\/`),
 		),
 	},
 	".pod": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Pod 6"),
-			regexp.MustCompile(`(?m)^[\s&&[^\n]]*=(comment|begin pod|begin para|item\d+)`),
+			regex.MustCompileRuby(`^[\s&&[^\n]]*=(comment|begin pod|begin para|item\d+)`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Pod"),
@@ -1237,40 +1253,40 @@ var ContentHeuristics = map[string]*Heuristics{
 	".pp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Pascal"),
-			regexp.MustCompile(`(?m)^\s*end[.;]`),
+			regex.MustCompileRuby(`^\s*end[.;]`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Puppet"),
-			regexp.MustCompile(`(?m)^\s+\w+\s+=>\s`),
+			regex.MustCompileRuby(`^\s+\w+\s+=>\s`),
 		),
 	},
 	".pro": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Proguard"),
-			regexp.MustCompile(`(?m)^-(include\b.*\.pro$|keep\b|keepclassmembers\b|keepattributes\b)`),
+			regex.MustCompileRuby(`^-(include\b.*\.pro$|keep\b|keepclassmembers\b|keepattributes\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Prolog"),
-			regexp.MustCompile(`(?m)^[^\[#]+:-`),
+			regex.MustCompileRuby(`^[^\[#]+:-`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("INI"),
-			regexp.MustCompile(`(?m)last_client=`),
+			regex.MustCompileRuby(`last_client=`),
 		),
 		rule.And(
 			rule.MatchingLanguages("QMake"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)HEADERS`),
+				regex.MustCompileRuby(`HEADERS`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)SOURCES`),
+				regex.MustCompileRuby(`SOURCES`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("IDL"),
-			regexp.MustCompile(`(?m)^\s*function[ \w,]+$`),
+			regex.MustCompileRuby(`^\s*function[ \w,]+$`),
 		),
 	},
 	".properties": &Heuristics{
@@ -1278,89 +1294,93 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("INI"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[^#!;][^=]*=`),
+				regex.MustCompileRuby(`^[^#!;][^=]*=`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[;\[]`),
+				regex.MustCompileRuby(`^[;\[]`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Java Properties"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[^#!;][^=]*=`),
+				regex.MustCompileRuby(`^[^#!;][^=]*=`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[#!]`),
+				regex.MustCompileRuby(`^[#!]`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("INI"),
-			regexp.MustCompile(`(?m)^[^#!;][^=]*=`),
+			regex.MustCompileRuby(`^[^#!;][^=]*=`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Java Properties"),
-			regexp.MustCompile(`(?m)^[^#!][^:]*:`),
+			regex.MustCompileRuby(`^[^#!][^:]*:`),
 		),
 	},
 	".q": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("q"),
-			regexp.MustCompile(`(?m)((?i:[A-Z.][\w.]*:{)|(^|\n)\\(cd?|d|l|p|ts?) )`),
+			regex.MustCompileRuby(`((?i:[A-Z.][\w.]*:{)|(^|\n)\\(cd?|d|l|p|ts?) )`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("HiveQL"),
-			regexp.MustCompile(`(?m)(?i:SELECT\s+[\w*,]+\s+FROM|(CREATE|ALTER|DROP)\s(DATABASE|SCHEMA|TABLE))`),
+			regex.MustCompileRuby(`(?i:SELECT\s+[\w*,]+\s+FROM|(CREATE|ALTER|DROP)\s(DATABASE|SCHEMA|TABLE))`),
 		),
 	},
 	".qs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Q#"),
-			regexp.MustCompile(`(?m)^((\/{2,3})?\s*(namespace|operation)\b)`),
+			regex.MustCompileRuby(`^((\/{2,3})?\s*(namespace|operation)\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Qt Script"),
-			regexp.MustCompile(`(?m)(\w+\.prototype\.\w+|===|\bvar\b)`),
+			regex.MustCompileRuby(`(\w+\.prototype\.\w+|===|\bvar\b)`),
 		),
 	},
 	".r": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Rebol"),
-			regexp.MustCompile(`(?m)(?i:\bRebol\b)`),
+			regex.MustCompileRuby(`(?i:\bRebol\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("R"),
-			regexp.MustCompile(`(?m)<-|^\s*#`),
+			regex.MustCompileRuby(`<-|^\s*#`),
 		),
 	},
 	".re": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Reason"),
-			regexp.MustCompile(`(?m)^\s*module\s+type\s|^\s*(?:include|open)\s+\w+\s*;\s*$|^\s*let\s+(?:module\s\w+\s*=\s*{|\w+:\s+.*=.*;\s*$)`),
+			regex.MustCompileRuby(`^\s*module\s+type\s|^\s*(?:include|open)\s+\w+\s*;\s*$|^\s*let\s+(?:module\s\w+\s*=\s*{|\w+:\s+.*=.*;\s*$)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("C++"),
-			regexp.MustCompile(`(?m)^\s*#(?:(?:if|ifdef|define|pragma)\s+\w|\s*include\s+<[^>]+>)|^\s*template\s*<`),
+			regex.MustCompileRuby(`^\s*#(?:(?:if|ifdef|define|pragma)\s+\w|\s*include\s+<[^>]+>)|^\s*template\s*<`),
 		),
 	},
 	".res": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("ReScript"),
-			regexp.MustCompile(`(?m)^\s*(let|module|type)\s+\w*\s+=\s+|^\s*(?:include|open)\s+\w+\s*$`),
+			regex.MustCompileRuby(`^\s*(let|module|type)\s+\w*\s+=\s+|^\s*(?:include|open)\s+\w+\s*$`),
 		),
 	},
 	".rno": &Heuristics{
 		rule.Or(
+			rule.MatchingLanguages("RUNOFF"),
+			regex.MustCompileRuby(`(?i:^\.!|^\f|\f$|^\.end lit(?:eral)?\b|^\.[a-zA-Z].*?;\.[a-zA-Z](?:[; \t])|\^\*[^\s*][^*]*\\\*(?=$|\s)|^\.c;[ \t]*\w+)`),
+		),
+		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.\\" `),
+			regex.MustCompileRuby(`^\.\\" `),
 		),
 	},
 	".rpy": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Python"),
-			regexp.MustCompile(`(?m)(?m:^(import|from|class|def)\s)`),
+			regex.MustCompileRuby(`(?m:^(import|from|class|def)\s)`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Ren'Py"),
@@ -1369,55 +1389,59 @@ var ContentHeuristics = map[string]*Heuristics{
 	".rs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Rust"),
-			regexp.MustCompile(`(?m)^(use |fn |mod |pub |macro_rules|impl|#!?\[)`),
+			regex.MustCompileRuby(`^(use |fn |mod |pub |macro_rules|impl|#!?\[)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("RenderScript"),
-			regexp.MustCompile(`(?m)#include|#pragma\s+(rs|version)|__attribute__`),
+			regex.MustCompileRuby(`#include|#pragma\s+(rs|version)|__attribute__`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)^\s*<\?xml`),
+			regex.MustCompileRuby(`^\s*<\?xml`),
 		),
 	},
 	".s": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Motorola 68K Assembly"),
-			regexp.MustCompile(`(?m)(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
+			regex.MustCompileRuby(`(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
 		),
 	},
 	".sc": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("SuperCollider"),
-			regexp.MustCompile(`(?m)(?i:\^(this|super)\.|^\s*~\w+\s*=\.)`),
+			regex.MustCompileRuby(`(?i:\^(this|super)\.|^\s*~\w+\s*=\.)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Scala"),
-			regexp.MustCompile(`(?m)(^\s*import (scala|java)\.|^\s*class\b)`),
+			regex.MustCompileRuby(`(^\s*import (scala|java)\.|^\s*class\b)`),
 		),
 	},
 	".sol": &Heuristics{
 		rule.Or(
+			rule.MatchingLanguages("Solidity"),
+			regex.MustCompileRuby(`\bpragma\s+solidity\b|\b(?:abstract\s+)?contract\s+(?!\d)[a-zA-Z0-9$_]+(?:\s+is\s+(?:[a-zA-Z0-9$_][^\{]*?)?)?\s*\{`),
+		),
+		rule.Or(
 			rule.MatchingLanguages("Gerber Image"),
-			regexp.MustCompile(`(?m)^[DGMT][0-9]{2}\*\r?\n`),
+			regex.MustCompileRuby(`^[DGMT][0-9]{2}\*\r?\n`),
 		),
 	},
 	".sql": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("PLpgSQL"),
-			regexp.MustCompile(`(?m)(?i:^\\i\b|AS\s+\$\$|LANGUAGE\s+'?plpgsql'?|BEGIN(\s+WORK)?\s*;)`),
+			regex.MustCompileRuby(`(?i:^\\i\b|AS\s+\$\$|LANGUAGE\s+'?plpgsql'?|BEGIN(\s+WORK)?\s*;)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("SQLPL"),
-			regexp.MustCompile(`(?m)(?i:ALTER\s+MODULE|MODE\s+DB2SQL|\bSYS(CAT|PROC)\.|ASSOCIATE\s+RESULT\s+SET|\bEND!\s*$)`),
+			regex.MustCompileRuby(`(?i:ALTER\s+MODULE|MODE\s+DB2SQL|\bSYS(CAT|PROC)\.|ASSOCIATE\s+RESULT\s+SET|\bEND!\s*$)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("PLSQL"),
-			regexp.MustCompile(`(?m)(?i:\$\$PLSQL_|XMLTYPE|systimestamp|\.nextval|CONNECT\s+BY|AUTHID\s+(DEFINER|CURRENT_USER)|constructor\W+function)`),
+			regex.MustCompileRuby(`(?i:\$\$PLSQL_|XMLTYPE|systimestamp|\.nextval|CONNECT\s+BY|AUTHID\s+(DEFINER|CURRENT_USER)|constructor\W+function)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("TSQL"),
-			regexp.MustCompile(`(?m)(?i:^\s*GO\b|BEGIN(\s+TRY|\s+CATCH)|OUTPUT\s+INSERTED|DECLARE\s+@|\[dbo\])`),
+			regex.MustCompileRuby(`(?i:^\s*GO\b|BEGIN(\s+TRY|\s+CATCH)|OUTPUT\s+INSERTED|DECLARE\s+@|\[dbo\])`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("SQL"),
@@ -1426,43 +1450,47 @@ var ContentHeuristics = map[string]*Heuristics{
 	".srt": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("SubRip Text"),
-			regexp.MustCompile(`(?m)^(\d{2}:\d{2}:\d{2},\d{3})\s*(-->)\s*(\d{2}:\d{2}:\d{2},\d{3})$`),
+			regex.MustCompileRuby(`^(\d{2}:\d{2}:\d{2},\d{3})\s*(-->)\s*(\d{2}:\d{2}:\d{2},\d{3})$`),
 		),
 	},
 	".st": &Heuristics{
 		rule.Or(
+			rule.MatchingLanguages("StringTemplate"),
+			regex.MustCompileRuby(`\$\w+[($]|(.)!\s*.+?\s*!\1|<!\s*.+?\s*!>|\[!\s*.+?\s*!\]|\{!\s*.+?\s*!\}`),
+		),
+		rule.Or(
 			rule.MatchingLanguages("Smalltalk"),
-			regexp.MustCompile(`(?m)\A\s*[\[{(^"'\w#]|[a-zA-Z_]\w*\s*:=\s*[a-zA-Z_]\w*|class\s*>>\s*[a-zA-Z_]\w*|^[a-zA-Z_]\w*\s+[a-zA-Z_]\w*:|^Class\s*{|if(?:True|False):\s*\[`),
+			regex.MustCompileRuby(`\A\s*[\[{(^"'\w#]|[a-zA-Z_]\w*\s*:=\s*[a-zA-Z_]\w*|class\s*>>\s*[a-zA-Z_]\w*|^[a-zA-Z_]\w*\s+[a-zA-Z_]\w*:|^Class\s*{|if(?:True|False):\s*\[`),
 		),
 	},
 	".t": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Perl"),
-			regexp.MustCompile(`(?m)\buse\s+(?:strict\b|v?5\.)`),
+			regex.MustCompileRuby(`\buse\s+(?:strict\b|v?5\.)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Raku"),
-			regexp.MustCompile(`(?m)^\s*(?:use\s+v6\b|\bmodule\b|\bmy\s+class\b)`),
+			regex.MustCompileRuby(`^\s*(?:use\s+v6\b|\bmodule\b|\bmy\s+class\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Turing"),
-			regexp.MustCompile(`(?m)^\s*%[ \t]+|^\s*var\s+\w+(\s*:\s*\w+)?\s*:=\s*\w+`),
+			regex.MustCompileRuby(`^\s*%[ \t]+|^\s*var\s+\w+(\s*:\s*\w+)?\s*:=\s*\w+`),
 		),
 	},
 	".toc": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("World of Warcraft Addon Data"),
-			regexp.MustCompile(`(?m)^## |@no-lib-strip@`),
+			regex.MustCompileRuby(`^## |@no-lib-strip@`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("TeX"),
-			regexp.MustCompile(`(?m)^\\(contentsline|defcounter|beamer|boolfalse)`),
+			regex.MustCompileRuby(`^\\(contentsline|defcounter|beamer|boolfalse)`),
 		),
 	},
 	".ts": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)<TS\b`),
+			regex.MustCompileRuby(`<TS\b`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("TypeScript"),
@@ -1471,7 +1499,7 @@ var ContentHeuristics = map[string]*Heuristics{
 	".tst": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("GAP"),
-			regexp.MustCompile(`(?m)gap> `),
+			regex.MustCompileRuby(`gap> `),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Scilab"),
@@ -1480,14 +1508,18 @@ var ContentHeuristics = map[string]*Heuristics{
 	".tsx": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("TSX"),
-			regexp.MustCompile(`(?m)^\s*(import.+(from\s+|require\()['"]react|\/\/\/\s*<reference\s)`),
+			regex.MustCompileRuby(`^\s*(import.+(from\s+|require\()['"]react|\/\/\/\s*<reference\s)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)(?i:^\s*<\?xml\s+version)`),
+			regex.MustCompileRuby(`(?i:^\s*<\?xml\s+version)`),
 		),
 	},
 	".txt": &Heuristics{
+		rule.Or(
+			rule.MatchingLanguages("Vim Help File"),
+			regex.MustCompileRuby(`(?:(?:^|[ \t])(?:vi|Vi(?=m))(?:m[<=>]?[0-9]+|m)?|[ \t]ex)(?=:(?=[ \t]*set?[ \t][^\r\n:]+:)|:(?![ \t]*set?[ \t]))(?:(?:[ \t]*:[ \t]*|[ \t])\w*(?:[ \t]*=(?:[^\\\s]|\\.)*)?)*[ \t:](?:filetype|ft|syntax)[ \t]*=(help)(?=$|\s|:)`),
+		),
 		rule.Always(
 			rule.MatchingLanguages("Text"),
 		),
@@ -1495,21 +1527,21 @@ var ContentHeuristics = map[string]*Heuristics{
 	".v": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Coq"),
-			regexp.MustCompile(`(?m)(?:^|\s)(?:Proof|Qed)\.(?:$|\s)|(?:^|\s)Require[ \t]+(Import|Export)\s`),
+			regex.MustCompileRuby(`(?:^|\s)(?:Proof|Qed)\.(?:$|\s)|(?:^|\s)Require[ \t]+(Import|Export)\s`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Verilog"),
-			regexp.MustCompile(`(?m)^[ \t]*module\s+[^\s()]+\s+\#?\(|^[ \t]*`+"`"+`(?:define|ifdef|ifndef|include|timescale)|^[ \t]*always[ \t]+@|^[ \t]*initial[ \t]+(begin|@)`),
+			regex.MustCompileRuby(`^[ \t]*module\s+[^\s()]+\s+\#?\(|^[ \t]*`+"`"+`(?:define|ifdef|ifndef|include|timescale)|^[ \t]*always[ \t]+@|^[ \t]*initial[ \t]+(begin|@)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("V"),
-			regexp.MustCompile(`(?m)\$(?:if|else)[ \t]|^[ \t]*fn\s+[^\s()]+\(.*?\).*?\{|^[ \t]*for\s*\{`),
+			regex.MustCompileRuby(`\$(?:if|else)[ \t]|^[ \t]*fn\s+[^\s()]+\(.*?\).*?\{|^[ \t]*for\s*\{`),
 		),
 	},
 	".vba": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Vim script"),
-			regexp.MustCompile(`(?m)^UseVimball`),
+			regex.MustCompileRuby(`^UseVimball`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("VBA"),
@@ -1518,35 +1550,35 @@ var ContentHeuristics = map[string]*Heuristics{
 	".w": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("OpenEdge ABL"),
-			regexp.MustCompile(`(?m)&ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS`),
+			regex.MustCompileRuby(`&ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("CWeb"),
-			regexp.MustCompile(`(?m)^@(<|\w+\.)`),
+			regex.MustCompileRuby(`^@(<|\w+\.)`),
 		),
 	},
 	".x": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("DirectX 3D File"),
-			regexp.MustCompile(`(?m)^xof 030(2|3)(?:txt|bin|tzip|bzip)\b`),
+			regex.MustCompileRuby(`^xof 030(2|3)(?:txt|bin|tzip|bzip)\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("RPC"),
-			regexp.MustCompile(`(?m)\b(program|version)\s+\w+\s*{|\bunion\s+\w+\s+switch\s*\(`),
+			regex.MustCompileRuby(`\b(program|version)\s+\w+\s*{|\bunion\s+\w+\s+switch\s*\(`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Logos"),
-			regexp.MustCompile(`(?m)^%(end|ctor|hook|group)\b`),
+			regex.MustCompileRuby(`^%(end|ctor|hook|group)\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Linker Script"),
-			regexp.MustCompile(`(?m)OUTPUT_ARCH\(|OUTPUT_FORMAT\(|SECTIONS`),
+			regex.MustCompileRuby(`OUTPUT_ARCH\(|OUTPUT_FORMAT\(|SECTIONS`),
 		),
 	},
 	".yy": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("JSON"),
-			regexp.MustCompile(`(?m)\"modelName\"\:\s*\"GM`),
+			regex.MustCompileRuby(`\"modelName\"\:\s*\"GM`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Yacc"),

--- a/data/heuristics_test.go
+++ b/data/heuristics_test.go
@@ -1,10 +1,10 @@
 package data
 
 import (
-	"regexp"
 	"testing"
 
 	"github.com/go-enry/go-enry/v2/data/rule"
+	"github.com/go-enry/go-enry/v2/regex"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -12,11 +12,11 @@ var testContentHeuristics = map[string]*Heuristics{
 	".md": &Heuristics{ // final pattern for parsed YAML rule
 		rule.Or(
 			rule.MatchingLanguages("Markdown"),
-			regexp.MustCompile(`(^[-A-Za-z0-9=#!\*\[|>])|<\/ | \A\z`),
+			regex.MustCompile(`(^[-A-Za-z0-9=#!\*\[|>])|<\/ | \A\z`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("GCC Machine Description"),
-			regexp.MustCompile(`^(;;|\(define_)`),
+			regex.MustCompile(`^(;;|\(define_)`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Markdown"),
@@ -26,15 +26,15 @@ var testContentHeuristics = map[string]*Heuristics{
 		// Order defines precedence: And, Or, Not, Named, Always
 		rule.And(
 			rule.MatchingLanguages("Unix Assembly"),
-			rule.Not(rule.MatchingLanguages(""), regexp.MustCompile(`/\*`)),
+			rule.Not(rule.MatchingLanguages(""), regex.MustCompile(`/\*`)),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`^\s*\.(?:include\s|globa?l\s|[A-Za-z][_A-Za-z0-9]*:)`),
+				regex.MustCompile(`^\s*\.(?:include\s|globa?l\s|[A-Za-z][_A-Za-z0-9]*:)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`^[.''][A-Za-z]{2}(\s|$)`),
+			regex.MustCompile(`^[.''][A-Za-z]{2}(\s|$)`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("MAXScript"),

--- a/data/rule/rule_test.go
+++ b/data/rule/rule_test.go
@@ -1,9 +1,9 @@
 package rule
 
 import (
-	"regexp"
 	"testing"
 
+	"github.com/go-enry/go-enry/v2/regex"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,13 +13,16 @@ var fixtures = []struct {
 	name     string
 	rule     Heuristic
 	numLangs int
-	matching string
+	match    string
 	noMatch  string
 }{
 	{"Always", Always(MatchingLanguages(lang)), 1, "a", ""},
-	{"Not", Not(MatchingLanguages(lang), regexp.MustCompile(`a`)), 1, "b", "a"},
-	{"And", And(MatchingLanguages(lang), regexp.MustCompile(`a`), regexp.MustCompile(`b`)), 1, "ab", "a"},
-	{"Or", Or(MatchingLanguages(lang), regexp.MustCompile(`a|b`)), 1, "ab", "c"},
+	{"Not", Not(MatchingLanguages(lang), regex.MustCompile(`a`)), 1, "b", "a"},
+	{"And", And(MatchingLanguages(lang), regex.MustCompile(`a`), regex.MustCompile(`b`)), 1, "ab", "a"},
+	{"Or", Or(MatchingLanguages(lang), regex.MustCompile(`a|b`)), 1, "ab", "c"},
+
+	{"OrNil", Or(MatchingLanguages(lang), regex.EnryRegexp(nil)), 1, "", "c"},
+	{"NotNil", Not(MatchingLanguages(lang), regex.EnryRegexp(nil)), 1, "b", ""},
 }
 
 func TestRules(t *testing.T) {
@@ -28,8 +31,12 @@ func TestRules(t *testing.T) {
 			assert.NotNil(t, f.rule)
 			assert.NotNil(t, f.rule.Languages())
 			assert.Equal(t, f.numLangs, len(f.rule.Languages()))
-			assert.Truef(t, f.rule.Match([]byte(f.matching)),
-				"'%s' is expected to .Match() by rule %s%v", f.matching, f.name, f.rule)
+
+			if f.match != "" {
+				assert.Truef(t, f.rule.Match([]byte(f.match)),
+					"'%s' is expected to .Match() by rule %s%v", f.match, f.name, f.rule)
+			}
+
 			if f.noMatch != "" {
 				assert.Falsef(t, f.rule.Match([]byte(f.noMatch)),
 					"'%s' is expected NOT to .Match() by rule %s%v", f.noMatch, f.name, f.rule)

--- a/internal/code-generator/assets/content.go.tmpl
+++ b/internal/code-generator/assets/content.go.tmpl
@@ -1,8 +1,7 @@
 package data
 
 import (
-	"regexp"
-
+	"github.com/go-enry/go-enry/v2/regex"
 	"github.com/go-enry/go-enry/v2/data/rule"
 )
 
@@ -27,12 +26,12 @@ var ContentHeuristics = map[string]*Heuristics{
 	{{- else if eq .Op "Or" -}}
 		rule.Or(
 			{{ template "Languages" .Langs -}}
-			regexp.MustCompile({{ .Pattern | stringVal }}),
+			regex.MustCompileRuby({{ .Pattern | stringVal }}),
 		),
 	{{- else if eq .Op "Not" -}}
 		rule.Not(
 			{{ template "Languages" .Langs -}}
-			regexp.MustCompile({{ .Pattern | stringVal }}),
+			regex.MustCompileRuby({{ .Pattern | stringVal }}),
 		),
 	{{- else if eq .Op "Always" -}}
 		rule.Always(

--- a/internal/code-generator/generator/test_files/content.gold
+++ b/internal/code-generator/generator/test_files/content.gold
@@ -4,9 +4,8 @@
 package data
 
 import (
-	"regexp"
-
 	"github.com/go-enry/go-enry/v2/data/rule"
+	"github.com/go-enry/go-enry/v2/regex"
 )
 
 var ContentHeuristics = map[string]*Heuristics{
@@ -15,31 +14,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".1in": &Heuristics{
@@ -47,26 +46,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -78,26 +77,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -109,26 +108,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -140,31 +139,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".3": &Heuristics{
@@ -172,31 +171,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".3in": &Heuristics{
@@ -204,26 +203,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -235,26 +234,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -266,26 +265,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -297,26 +296,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -328,26 +327,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -359,26 +358,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -390,31 +389,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".5": &Heuristics{
@@ -422,31 +421,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".6": &Heuristics{
@@ -454,31 +453,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".7": &Heuristics{
@@ -486,31 +485,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".8": &Heuristics{
@@ -518,31 +517,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".9": &Heuristics{
@@ -550,31 +549,31 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
+			regex.MustCompileRuby(`^\.(?:[A-Za-z]{2}(?:\s|$)|\\")`),
 		),
 	},
 	".al": &Heuristics{
@@ -582,38 +581,43 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("AL"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)\b(?i:(CODEUNIT|PAGE|PAGEEXTENSION|PAGECUSTOMIZATION|DOTNET|ENUM|ENUMEXTENSION|VALUE|QUERY|REPORT|TABLE|TABLEEXTENSION|XMLPORT|PROFILE|CONTROLADDIN))\b`),
+				regex.MustCompileRuby(`\b(?i:(CODEUNIT|PAGE|PAGEEXTENSION|PAGECUSTOMIZATION|DOTNET|ENUM|ENUMEXTENSION|VALUE|QUERY|REPORT|TABLE|TABLEEXTENSION|XMLPORT|PROFILE|CONTROLADDIN))\b`),
 			),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Perl"),
 		),
 	},
-	".as": &Heuristics{},
+	".as": &Heuristics{
+		rule.Or(
+			rule.MatchingLanguages("ActionScript"),
+			regex.MustCompileRuby(`^\s*(?:package(?:\s+[\w.]+)?\s+(?:{|$)|import\s+[\w.*]+\s*;|(?=.*?(?:intrinsic|extends))(intrinsic\s+)?class\s+[\w<>.]+(?:\s+extends\s+[\w<>.]+)?|(?:(?:public|protected|private|static)\s+)*(?:(?:var|const|local)\s+\w+\s*:\s*[\w<>.]+(?:\s*=.*)?\s*;|function\s+\w+\s*\((?:\s*\w+\s*:\s*[\w<>.]+\s*(,\s*\w+\s*:\s*[\w<>.]+\s*)*)?\)))`),
+		),
+	},
 	".asc": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Public Key"),
-			regexp.MustCompile(`(?m)^(----[- ]BEGIN|ssh-(rsa|dss)) `),
+			regex.MustCompileRuby(`^(----[- ]BEGIN|ssh-(rsa|dss)) `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("AsciiDoc"),
-			regexp.MustCompile(`(?m)^[=-]+(\s|\n)|{{[A-Za-z]`),
+			regex.MustCompileRuby(`^[=-]+(\s|\n)|{{[A-Za-z]`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("AGS Script"),
-			regexp.MustCompile(`(?m)^(\/\/.+|((import|export)\s+)?(function|int|float|char)\s+((room|repeatedly|on|game)_)?([A-Za-z]+[A-Za-z_0-9]+)\s*[;\(])`),
+			regex.MustCompileRuby(`^(\/\/.+|((import|export)\s+)?(function|int|float|char)\s+((room|repeatedly|on|game)_)?([A-Za-z]+[A-Za-z_0-9]+)\s*[;\(])`),
 		),
 	},
 	".asm": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Motorola 68K Assembly"),
-			regexp.MustCompile(`(?m)(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
+			regex.MustCompileRuby(`(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
 		),
 	},
 	".asy": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("LTspice Symbol"),
-			regexp.MustCompile(`(?m)^SymbolType[ \t]`),
+			regex.MustCompileRuby(`^SymbolType[ \t]`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Asymptote"),
@@ -622,163 +626,167 @@ var ContentHeuristics = map[string]*Heuristics{
 	".bas": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("FreeBasic"),
-			regexp.MustCompile(`(?m)^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s`),
+			regex.MustCompileRuby(`^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("BASIC"),
-			regexp.MustCompile(`(?m)^\s*\d+`),
+			regex.MustCompileRuby(`^\s*\d+`),
 		),
 	},
 	".bb": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("BlitzBasic"),
-			regexp.MustCompile(`(?m)(<^\s*; |End Function)`),
+			regex.MustCompileRuby(`(<^\s*; |End Function)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("BitBake"),
-			regexp.MustCompile(`(?m)^\s*(# |include|require)\b`),
+			regex.MustCompileRuby(`^\s*(# |include|require)\b`),
 		),
 	},
 	".bi": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("FreeBasic"),
-			regexp.MustCompile(`(?m)^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s`),
+			regex.MustCompileRuby(`^[ \t]*#(?:define|endif|endmacro|ifn?def|if|include|lang|macro)\s`),
 		),
 	},
 	".builds": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)^(\s*)(?i:<Project|<Import|<Property|<?xml|xmlns)`),
+			regex.MustCompileRuby(`^(\s*)(?i:<Project|<Import|<Property|<?xml|xmlns)`),
 		),
 	},
 	".ch": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("xBase"),
-			regexp.MustCompile(`(?m)^\s*#\s*(?i:if|ifdef|ifndef|define|command|xcommand|translate|xtranslate|include|pragma|undef)\b`),
+			regex.MustCompileRuby(`^\s*#\s*(?i:if|ifdef|ifndef|define|command|xcommand|translate|xtranslate|include|pragma|undef)\b`),
 		),
 	},
 	".cl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Common Lisp"),
-			regexp.MustCompile(`(?m)^\s*\((?i:defun|in-package|defpackage) `),
+			regex.MustCompileRuby(`^\s*\((?i:defun|in-package|defpackage) `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Cool"),
-			regexp.MustCompile(`(?m)^class`),
+			regex.MustCompileRuby(`^class`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("OpenCL"),
-			regexp.MustCompile(`(?m)\/\* |\/\/ |^\}`),
+			regex.MustCompileRuby(`\/\* |\/\/ |^\}`),
 		),
 	},
 	".cls": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("TeX"),
-			regexp.MustCompile(`(?m)^\s*\\(?:NeedsTeXFormat|ProvidesClass){`),
+			regex.MustCompileRuby(`^\s*\\(?:NeedsTeXFormat|ProvidesClass){`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("ObjectScript"),
-			regexp.MustCompile(`(?m)^Class\s`),
+			regex.MustCompileRuby(`^Class\s`),
 		),
 	},
 	".cmp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Gerber Image"),
-			regexp.MustCompile(`(?m)^[DGMT][0-9]{2}\*\r?\n`),
+			regex.MustCompileRuby(`^[DGMT][0-9]{2}\*\r?\n`),
 		),
 	},
 	".cs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Smalltalk"),
-			regexp.MustCompile(`(?m)![\w\s]+methodsFor: `),
+			regex.MustCompileRuby(`![\w\s]+methodsFor: `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("C#"),
-			regexp.MustCompile(`(?m)^(\s*namespace\s*[\w\.]+\s*{|\s*\/\/)`),
+			regex.MustCompileRuby(`^(\s*namespace\s*[\w\.]+\s*{|\s*\/\/)`),
 		),
 	},
 	".csl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)(?i:^\s*(\<\?xml|xmlns))`),
+			regex.MustCompileRuby(`(?i:^\s*(\<\?xml|xmlns))`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Kusto"),
-			regexp.MustCompile(`(?m)(^\|\s*(where|extend|project|limit|summarize))|(^\.\w+)`),
+			regex.MustCompileRuby(`(^\|\s*(where|extend|project|limit|summarize))|(^\.\w+)`),
 		),
 	},
 	".d": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("D"),
-			regexp.MustCompile(`(?m)^module\s+[\w.]*\s*;|import\s+[\w\s,.:]*;|\w+\s+\w+\s*\(.*\)(?:\(.*\))?\s*{[^}]*}|unittest\s*(?:\(.*\))?\s*{[^}]*}`),
+			regex.MustCompileRuby(`^module\s+[\w.]*\s*;|import\s+[\w\s,.:]*;|\w+\s+\w+\s*\(.*\)(?:\(.*\))?\s*{[^}]*}|unittest\s*(?:\(.*\))?\s*{[^}]*}`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("DTrace"),
-			regexp.MustCompile(`(?m)^(\w+:\w*:\w*:\w*|BEGIN|END|provider\s+|(tick|profile)-\w+\s+{[^}]*}|#pragma\s+D\s+(option|attributes|depends_on)\s|#pragma\s+ident\s)`),
+			regex.MustCompileRuby(`^(\w+:\w*:\w*:\w*|BEGIN|END|provider\s+|(tick|profile)-\w+\s+{[^}]*}|#pragma\s+D\s+(option|attributes|depends_on)\s|#pragma\s+ident\s)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Makefile"),
-			regexp.MustCompile(`(?m)([\/\\].*:\s+.*\s\\$|: \\$|^[ %]:|^[\w\s\/\\.]+\w+\.\w+\s*:\s+[\w\s\/\\.]+\w+\.\w+)`),
+			regex.MustCompileRuby(`([\/\\].*:\s+.*\s\\$|: \\$|^[ %]:|^[\w\s\/\\.]+\w+\.\w+\s*:\s+[\w\s\/\\.]+\w+\.\w+)`),
 		),
 	},
 	".dsp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Microsoft Developer Studio Project"),
-			regexp.MustCompile(`(?m)# Microsoft Developer Studio Generated Build File`),
+			regex.MustCompileRuby(`# Microsoft Developer Studio Generated Build File`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Faust"),
-			regexp.MustCompile(`(?m)\bprocess\s*[(=]|\b(library|import)\s*\(\s*"|\bdeclare\s+(name|version|author|copyright|license)\s+"`),
+			regex.MustCompileRuby(`\bprocess\s*[(=]|\b(library|import)\s*\(\s*"|\bdeclare\s+(name|version|author|copyright|license)\s+"`),
 		),
 	},
 	".ecl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("ECLiPSe"),
-			regexp.MustCompile(`(?m)^[^#]+:-`),
+			regex.MustCompileRuby(`^[^#]+:-`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("ECL"),
-			regexp.MustCompile(`(?m):=`),
+			regex.MustCompileRuby(`:=`),
 		),
 	},
 	".es": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Erlang"),
-			regexp.MustCompile(`(?m)^\s*(?:%%|main\s*\(.*?\)\s*->)`),
+			regex.MustCompileRuby(`^\s*(?:%%|main\s*\(.*?\)\s*->)`),
+		),
+		rule.Or(
+			rule.MatchingLanguages("JavaScript"),
+			regex.MustCompileRuby(`(?m:\/\/|("|')use strict\1|export\s+default\s|\/\*.*?\*\/)`),
 		),
 	},
 	".f": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Forth"),
-			regexp.MustCompile(`(?m)^: `),
+			regex.MustCompileRuby(`^: `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Filebench WML"),
-			regexp.MustCompile(`(?m)flowop`),
+			regex.MustCompileRuby(`flowop`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Fortran"),
-			regexp.MustCompile(`(?m)^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)`),
+			regex.MustCompileRuby(`^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)`),
 		),
 	},
 	".for": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Forth"),
-			regexp.MustCompile(`(?m)^: `),
+			regex.MustCompileRuby(`^: `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Fortran"),
-			regexp.MustCompile(`(?m)^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)`),
+			regex.MustCompileRuby(`^(?i:[c*][^abd-z]|      (subroutine|program|end|data)\s|\s*!)`),
 		),
 	},
 	".fr": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Forth"),
-			regexp.MustCompile(`(?m)^(: |also |new-device|previous )`),
+			regex.MustCompileRuby(`^(: |also |new-device|previous )`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Frege"),
-			regexp.MustCompile(`(?m)^\s*(import|module|package|data|type) `),
+			regex.MustCompileRuby(`^\s*(import|module|package|data|type) `),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Text"),
@@ -787,49 +795,53 @@ var ContentHeuristics = map[string]*Heuristics{
 	".fs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Forth"),
-			regexp.MustCompile(`(?m)^(: |new-device)`),
+			regex.MustCompileRuby(`^(: |new-device)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("F#"),
-			regexp.MustCompile(`(?m)^\s*(#light|import|let|module|namespace|open|type)`),
+			regex.MustCompileRuby(`^\s*(#light|import|let|module|namespace|open|type)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("GLSL"),
-			regexp.MustCompile(`(?m)^\s*(#version|precision|uniform|varying|vec[234])`),
+			regex.MustCompileRuby(`^\s*(#version|precision|uniform|varying|vec[234])`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Filterscript"),
-			regexp.MustCompile(`(?m)#include|#pragma\s+(rs|version)|__attribute__`),
+			regex.MustCompileRuby(`#include|#pragma\s+(rs|version)|__attribute__`),
 		),
 	},
 	".ftl": &Heuristics{
 		rule.Or(
+			rule.MatchingLanguages("FreeMarker"),
+			regex.MustCompileRuby(`^(?:<|[a-zA-Z-][a-zA-Z0-9_-]+[ \t]+\w)|\${\w+[^\n]*?}|^[ \t]*(?:<#--.*?-->|<#([a-z]+)(?=\s|>)[^>]*>.*?</#\1>|\[#--.*?--\]|\[#([a-z]+)(?=\s|\])[^\]]*\].*?\[#\2\])`),
+		),
+		rule.Or(
 			rule.MatchingLanguages("Fluent"),
-			regexp.MustCompile(`(?m)^-?[a-zA-Z][a-zA-Z0-9_-]* *=|\{\$-?[a-zA-Z][-\w]*(?:\.[a-zA-Z][-\w]*)?\}`),
+			regex.MustCompileRuby(`^-?[a-zA-Z][a-zA-Z0-9_-]* *=|\{\$-?[a-zA-Z][-\w]*(?:\.[a-zA-Z][-\w]*)?\}`),
 		),
 	},
 	".gd": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("GAP"),
-			regexp.MustCompile(`(?m)\s*(Declare|BindGlobal|KeyDependentOperation)`),
+			regex.MustCompileRuby(`\s*(Declare|BindGlobal|KeyDependentOperation)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("GDScript"),
-			regexp.MustCompile(`(?m)\s*(extends|var|const|enum|func|class|signal|tool|yield|assert|onready)`),
+			regex.MustCompileRuby(`\s*(extends|var|const|enum|func|class|signal|tool|yield|assert|onready)`),
 		),
 	},
 	".gml": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)(?i:^\s*(\<\?xml|xmlns))`),
+			regex.MustCompileRuby(`(?i:^\s*(\<\?xml|xmlns))`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Graph Modeling Language"),
-			regexp.MustCompile(`(?m)(?i:^\s*(graph|node)\s+\[$)`),
+			regex.MustCompileRuby(`(?i:^\s*(graph|node)\s+\[$)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Gerber Image"),
-			regexp.MustCompile(`(?m)^[DGMT][0-9]{2}\*$`),
+			regex.MustCompileRuby(`^[DGMT][0-9]{2}\*$`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Game Maker Language"),
@@ -838,25 +850,25 @@ var ContentHeuristics = map[string]*Heuristics{
 	".gs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("GLSL"),
-			regexp.MustCompile(`(?m)^#version\s+[0-9]+\b`),
+			regex.MustCompileRuby(`^#version\s+[0-9]+\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Gosu"),
-			regexp.MustCompile(`(?m)^uses (java|gw)\.`),
+			regex.MustCompileRuby(`^uses (java|gw)\.`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Genie"),
-			regexp.MustCompile(`(?m)^\[indent=[0-9]+\]`),
+			regex.MustCompileRuby(`^\[indent=[0-9]+\]`),
 		),
 	},
 	".h": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Objective-C"),
-			regexp.MustCompile(`(?m)^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])`),
+			regex.MustCompileRuby(`^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("C++"),
-			regexp.MustCompile(`(?m)^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>|^\s*template\s*<|^[ \t]*(try|constexpr)|^[ \t]*catch\s*\(|^[ \t]*(class|(using[ \t]+)?namespace)\s+\w+|^[ \t]*(private|public|protected):$|std::\w+`),
+			regex.MustCompileRuby(`^\s*#\s*include <(cstdint|string|vector|map|list|array|bitset|queue|stack|forward_list|unordered_map|unordered_set|(i|o|io)stream)>|^\s*template\s*<|^[ \t]*(try|constexpr)|^[ \t]*catch\s*\(|^[ \t]*(class|(using[ \t]+)?namespace)\s+\w+|^[ \t]*(private|public|protected):$|std::\w+`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("C"),
@@ -865,23 +877,23 @@ var ContentHeuristics = map[string]*Heuristics{
 	".hh": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Hack"),
-			regexp.MustCompile(`(?m)<\?hh`),
+			regex.MustCompileRuby(`<\?hh`),
 		),
 	},
 	".i": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Motorola 68K Assembly"),
-			regexp.MustCompile(`(?m)(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
+			regex.MustCompileRuby(`(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("SWIG"),
-			regexp.MustCompile(`(?m)^[ \t]*%[a-z_]+\b|^%[{}]$`),
+			regex.MustCompileRuby(`^[ \t]*%[a-z_]+\b|^%[{}]$`),
 		),
 	},
 	".ice": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("JSON"),
-			regexp.MustCompile(`(?m)\A\s*[{\[]`),
+			regex.MustCompileRuby(`\A\s*[{\[]`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Slice"),
@@ -890,57 +902,61 @@ var ContentHeuristics = map[string]*Heuristics{
 	".inc": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Motorola 68K Assembly"),
-			regexp.MustCompile(`(?m)(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
+			regex.MustCompileRuby(`(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("PHP"),
-			regexp.MustCompile(`(?m)^<\?(?:php)?`),
+			regex.MustCompileRuby(`^<\?(?:php)?`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("SourcePawn"),
-			regexp.MustCompile(`(?m)^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\)(?:\s*{)?)|^methodmap\s+\w+\s+<\s+\w+|^\s*MarkNativeAsOptional\s*\(`),
+			regex.MustCompileRuby(`^public\s+(?:SharedPlugin(?:\s+|:)__pl_\w+\s*=(?:\s*{)?|(?:void\s+)?__pl_\w+_SetNTVOptional\(\)(?:\s*{)?)|^methodmap\s+\w+\s+<\s+\w+|^\s*MarkNativeAsOptional\s*\(`),
+		),
+		rule.Or(
+			rule.MatchingLanguages("NASL"),
+			regex.MustCompileRuby(`^\s*include\s*\(\s*(?:"|')[\\/\w\-\.:\s]+\.(?:nasl|inc)\s*(?:"|')\s*\)\s*;|^\s*(?:global|local)_var\s+(?:\w+(?:\s*=\s*[\w\-"']+)?\s*)(?:,\s*\w+(?:\s*=\s*[\w\-"']+)?\s*)*+\s*;|^\s*namespace\s+\w+\s*{|^\s*object\s+\w+\s*(?:extends\s+\w+(?:::\w+)?)?\s*{|^\s*(?:public\s+|private\s+|\s*)function\s+\w+\s*\([\w\s,]*\)\s*{`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("POV-Ray SDL"),
-			regexp.MustCompile(`(?m)^\s*#(declare|local|macro|while)\s`),
+			regex.MustCompileRuby(`^\s*#(declare|local|macro|while)\s`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Pascal"),
-			regexp.MustCompile(`(?m)(?i:^\s*{\$(?:mode|ifdef|undef|define)[ ]+[a-z0-9_]+})|^\s*end[.;]\s*$`),
+			regex.MustCompileRuby(`(?i:^\s*{\$(?:mode|ifdef|undef|define)[ ]+[a-z0-9_]+})|^\s*end[.;]\s*$`),
 		),
 	},
 	".l": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Common Lisp"),
-			regexp.MustCompile(`(?m)\(def(un|macro)\s`),
+			regex.MustCompileRuby(`\(def(un|macro)\s`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Lex"),
-			regexp.MustCompile(`(?m)^(%[%{}]xs|<.*>)`),
+			regex.MustCompileRuby(`^(%[%{}]xs|<.*>)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.[A-Za-z]{2}(\s|$)`),
+			regex.MustCompileRuby(`^\.[A-Za-z]{2}(\s|$)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("PicoLisp"),
-			regexp.MustCompile(`(?m)^\((de|class|rel|code|data|must)\s`),
+			regex.MustCompileRuby(`^\((de|class|rel|code|data|must)\s`),
 		),
 	},
 	".lisp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Common Lisp"),
-			regexp.MustCompile(`(?m)^\s*\((?i:defun|in-package|defpackage) `),
+			regex.MustCompileRuby(`^\s*\((?i:defun|in-package|defpackage) `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("NewLisp"),
-			regexp.MustCompile(`(?m)^\s*\(define `),
+			regex.MustCompileRuby(`^\s*\(define `),
 		),
 	},
 	".ls": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("LoomScript"),
-			regexp.MustCompile(`(?m)^\s*package\s*[\w\.\/\*\s]*\s*{`),
+			regex.MustCompileRuby(`^\s*package\s*[\w\.\/\*\s]*\s*{`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("LiveScript"),
@@ -949,54 +965,54 @@ var ContentHeuristics = map[string]*Heuristics{
 	".lsp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Common Lisp"),
-			regexp.MustCompile(`(?m)^\s*\((?i:defun|in-package|defpackage) `),
+			regex.MustCompileRuby(`^\s*\((?i:defun|in-package|defpackage) `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("NewLisp"),
-			regexp.MustCompile(`(?m)^\s*\(define `),
+			regex.MustCompileRuby(`^\s*\(define `),
 		),
 	},
 	".m": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Objective-C"),
-			regexp.MustCompile(`(?m)^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])`),
+			regex.MustCompileRuby(`^\s*(@(interface|class|protocol|property|end|synchronised|selector|implementation)\b|#import\s+.+\.h[">])`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Mercury"),
-			regexp.MustCompile(`(?m):- module`),
+			regex.MustCompileRuby(`:- module`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("MUF"),
-			regexp.MustCompile(`(?m)^: `),
+			regex.MustCompileRuby(`^: `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("M"),
-			regexp.MustCompile(`(?m)^\s*;`),
+			regex.MustCompileRuby(`^\s*;`),
 		),
 		rule.And(
 			rule.MatchingLanguages("Mathematica"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)\(\*`),
+				regex.MustCompileRuby(`\(\*`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)\*\)$`),
+				regex.MustCompileRuby(`\*\)$`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("MATLAB"),
-			regexp.MustCompile(`(?m)^\s*%`),
+			regex.MustCompileRuby(`^\s*%`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Limbo"),
-			regexp.MustCompile(`(?m)^\w+\s*:\s*module\s*{`),
+			regex.MustCompileRuby(`^\w+\s*:\s*module\s*{`),
 		),
 	},
 	".m4": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("M4Sugar"),
-			regexp.MustCompile(`(?m)AC_DEFUN|AC_PREREQ|AC_INIT|^_?m4_`),
+			regex.MustCompileRuby(`AC_DEFUN|AC_PREREQ|AC_INIT|^_?m4_`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("M4"),
@@ -1007,26 +1023,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -1036,17 +1052,17 @@ var ContentHeuristics = map[string]*Heuristics{
 	".mask": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Unity3d Asset"),
-			regexp.MustCompile(`(?m)tag:unity3d.com`),
+			regex.MustCompileRuby(`tag:unity3d.com`),
 		),
 	},
 	".md": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Markdown"),
-			regexp.MustCompile(`(?m)(^[-A-Za-z0-9=#!\*\[|>])|<\/|\A\z`),
+			regex.MustCompileRuby(`(^[-A-Za-z0-9=#!\*\[|>])|<\/|\A\z`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("GCC Machine Description"),
-			regexp.MustCompile(`(?m)^(;;|\(define_)`),
+			regex.MustCompileRuby(`^(;;|\(define_)`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Markdown"),
@@ -1057,26 +1073,26 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dd +(?:[^"\s]+|"[^"]+")`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*Dt +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
+				regex.MustCompileRuby(`^[.'][ \t]*Sh +(?:[^"\s]|"[^"]+")`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Roff Manpage"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
+				regex.MustCompileRuby(`^[.'][ \t]*TH +(?:[^"\s]+|"[^"]+") +"?(?:[1-9]|@[^\s@]+@)`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
+				regex.MustCompileRuby(`^[.'][ \t]*SH +(?:[^"\s]+|"[^"\s]+)`),
 			),
 		),
 		rule.Always(
@@ -1086,21 +1102,21 @@ var ContentHeuristics = map[string]*Heuristics{
 	".ml": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("OCaml"),
-			regexp.MustCompile(`(?m)(^\s*module)|let rec |match\s+(\S+\s)+with`),
+			regex.MustCompileRuby(`(^\s*module)|let rec |match\s+(\S+\s)+with`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Standard ML"),
-			regexp.MustCompile(`(?m)=> |case\s+(\S+\s)+of`),
+			regex.MustCompileRuby(`=> |case\s+(\S+\s)+of`),
 		),
 	},
 	".mod": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)<!ENTITY `),
+			regex.MustCompileRuby(`<!ENTITY `),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Modula-2"),
-			regexp.MustCompile(`(?m)^\s*(?i:MODULE|END) [\w\.]+;`),
+			regex.MustCompileRuby(`^\s*(?i:MODULE|END) [\w\.]+;`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Linux Kernel Module", "AMPL"),
@@ -1109,17 +1125,17 @@ var ContentHeuristics = map[string]*Heuristics{
 	".ms": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^[.'][A-Za-z]{2}(\s|$)`),
+			regex.MustCompileRuby(`^[.'][A-Za-z]{2}(\s|$)`),
 		),
 		rule.And(
 			rule.MatchingLanguages("Unix Assembly"),
 			rule.Not(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)/\*`),
+				regex.MustCompileRuby(`/\*`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^\s*\.(?:include\s|globa?l\s|[A-Za-z][_A-Za-z0-9]*:)`),
+				regex.MustCompileRuby(`^\s*\.(?:include\s|globa?l\s|[A-Za-z][_A-Za-z0-9]*:)`),
 			),
 		),
 		rule.Always(
@@ -1129,31 +1145,31 @@ var ContentHeuristics = map[string]*Heuristics{
 	".n": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^[.']`),
+			regex.MustCompileRuby(`^[.']`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Nemerle"),
-			regexp.MustCompile(`(?m)^(module|namespace|using)\s`),
+			regex.MustCompileRuby(`^(module|namespace|using)\s`),
 		),
 	},
 	".ncl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)^\s*<\?xml\s+version`),
+			regex.MustCompileRuby(`^\s*<\?xml\s+version`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Gerber Image"),
-			regexp.MustCompile(`(?m)^[DGMT][0-9]{2}\*\r?\n`),
+			regex.MustCompileRuby(`^[DGMT][0-9]{2}\*\r?\n`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Text"),
-			regexp.MustCompile(`(?m)THE_TITLE`),
+			regex.MustCompileRuby(`THE_TITLE`),
 		),
 	},
 	".nl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("NL"),
-			regexp.MustCompile(`(?m)^(b|g)[0-9]+ `),
+			regex.MustCompileRuby(`^(b|g)[0-9]+ `),
 		),
 		rule.Always(
 			rule.MatchingLanguages("NewLisp"),
@@ -1162,17 +1178,17 @@ var ContentHeuristics = map[string]*Heuristics{
 	".odin": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Object Data Instance Notation"),
-			regexp.MustCompile(`(?m)(?:^|<)\s*[A-Za-z0-9_]+\s*=\s*<`),
+			regex.MustCompileRuby(`(?:^|<)\s*[A-Za-z0-9_]+\s*=\s*<`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Odin"),
-			regexp.MustCompile(`(?m)package\s+\w+|\b(?:im|ex)port\s*"[\w:./]+"|\w+\s*::\s*(?:proc|struct)\s*\(|^\s*//\s`),
+			regex.MustCompileRuby(`package\s+\w+|\b(?:im|ex)port\s*"[\w:./]+"|\w+\s*::\s*(?:proc|struct)\s*\(|^\s*//\s`),
 		),
 	},
 	".p": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Gnuplot"),
-			regexp.MustCompile(`(?m)^s?plot\b|^set\s+(term|terminal|out|output|[xy]tics|[xy]label|[xy]range|style)\b`),
+			regex.MustCompileRuby(`^s?plot\b|^set\s+(term|terminal|out|output|[xy]tics|[xy]label|[xy]range|style)\b`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("OpenEdge ABL"),
@@ -1181,31 +1197,31 @@ var ContentHeuristics = map[string]*Heuristics{
 	".php": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Hack"),
-			regexp.MustCompile(`(?m)<\?hh`),
+			regex.MustCompileRuby(`<\?hh`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("PHP"),
-			regexp.MustCompile(`(?m)<\?[^h]`),
+			regex.MustCompileRuby(`<\?[^h]`),
 		),
 	},
 	".pl": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Prolog"),
-			regexp.MustCompile(`(?m)^[^#]*:-`),
+			regex.MustCompileRuby(`^[^#]*:-`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Perl"),
-			regexp.MustCompile(`(?m)\buse\s+(?:strict\b|v?5\.)`),
+			regex.MustCompileRuby(`\buse\s+(?:strict\b|v?5\.)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Raku"),
-			regexp.MustCompile(`(?m)^\s*(?:use\s+v6\b|\bmodule\b|\b(?:my\s+)?class\b)`),
+			regex.MustCompileRuby(`^\s*(?:use\s+v6\b|\bmodule\b|\b(?:my\s+)?class\b)`),
 		),
 	},
 	".plist": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML Property List"),
-			regexp.MustCompile(`(?m)<!DOCTYPE\s+plist`),
+			regex.MustCompileRuby(`<!DOCTYPE\s+plist`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("OpenStep Property List"),
@@ -1214,21 +1230,21 @@ var ContentHeuristics = map[string]*Heuristics{
 	".pm": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Perl"),
-			regexp.MustCompile(`(?m)\buse\s+(?:strict\b|v?5\.)`),
+			regex.MustCompileRuby(`\buse\s+(?:strict\b|v?5\.)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Raku"),
-			regexp.MustCompile(`(?m)^\s*(?:use\s+v6\b|\bmodule\b|\b(?:my\s+)?class\b)`),
+			regex.MustCompileRuby(`^\s*(?:use\s+v6\b|\bmodule\b|\b(?:my\s+)?class\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("X PixMap"),
-			regexp.MustCompile(`(?m)^\s*\/\* XPM \*\/`),
+			regex.MustCompileRuby(`^\s*\/\* XPM \*\/`),
 		),
 	},
 	".pod": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Pod 6"),
-			regexp.MustCompile(`(?m)^[\s&&[^\n]]*=(comment|begin pod|begin para|item\d+)`),
+			regex.MustCompileRuby(`^[\s&&[^\n]]*=(comment|begin pod|begin para|item\d+)`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Pod"),
@@ -1237,40 +1253,40 @@ var ContentHeuristics = map[string]*Heuristics{
 	".pp": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Pascal"),
-			regexp.MustCompile(`(?m)^\s*end[.;]`),
+			regex.MustCompileRuby(`^\s*end[.;]`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Puppet"),
-			regexp.MustCompile(`(?m)^\s+\w+\s+=>\s`),
+			regex.MustCompileRuby(`^\s+\w+\s+=>\s`),
 		),
 	},
 	".pro": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Proguard"),
-			regexp.MustCompile(`(?m)^-(include\b.*\.pro$|keep\b|keepclassmembers\b|keepattributes\b)`),
+			regex.MustCompileRuby(`^-(include\b.*\.pro$|keep\b|keepclassmembers\b|keepattributes\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Prolog"),
-			regexp.MustCompile(`(?m)^[^\[#]+:-`),
+			regex.MustCompileRuby(`^[^\[#]+:-`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("INI"),
-			regexp.MustCompile(`(?m)last_client=`),
+			regex.MustCompileRuby(`last_client=`),
 		),
 		rule.And(
 			rule.MatchingLanguages("QMake"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)HEADERS`),
+				regex.MustCompileRuby(`HEADERS`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)SOURCES`),
+				regex.MustCompileRuby(`SOURCES`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("IDL"),
-			regexp.MustCompile(`(?m)^\s*function[ \w,]+$`),
+			regex.MustCompileRuby(`^\s*function[ \w,]+$`),
 		),
 	},
 	".properties": &Heuristics{
@@ -1278,89 +1294,93 @@ var ContentHeuristics = map[string]*Heuristics{
 			rule.MatchingLanguages("INI"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[^#!;][^=]*=`),
+				regex.MustCompileRuby(`^[^#!;][^=]*=`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[;\[]`),
+				regex.MustCompileRuby(`^[;\[]`),
 			),
 		),
 		rule.And(
 			rule.MatchingLanguages("Java Properties"),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[^#!;][^=]*=`),
+				regex.MustCompileRuby(`^[^#!;][^=]*=`),
 			),
 			rule.Or(
 				rule.MatchingLanguages(""),
-				regexp.MustCompile(`(?m)^[#!]`),
+				regex.MustCompileRuby(`^[#!]`),
 			),
 		),
 		rule.Or(
 			rule.MatchingLanguages("INI"),
-			regexp.MustCompile(`(?m)^[^#!;][^=]*=`),
+			regex.MustCompileRuby(`^[^#!;][^=]*=`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Java Properties"),
-			regexp.MustCompile(`(?m)^[^#!][^:]*:`),
+			regex.MustCompileRuby(`^[^#!][^:]*:`),
 		),
 	},
 	".q": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("q"),
-			regexp.MustCompile(`(?m)((?i:[A-Z.][\w.]*:{)|(^|\n)\\(cd?|d|l|p|ts?) )`),
+			regex.MustCompileRuby(`((?i:[A-Z.][\w.]*:{)|(^|\n)\\(cd?|d|l|p|ts?) )`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("HiveQL"),
-			regexp.MustCompile(`(?m)(?i:SELECT\s+[\w*,]+\s+FROM|(CREATE|ALTER|DROP)\s(DATABASE|SCHEMA|TABLE))`),
+			regex.MustCompileRuby(`(?i:SELECT\s+[\w*,]+\s+FROM|(CREATE|ALTER|DROP)\s(DATABASE|SCHEMA|TABLE))`),
 		),
 	},
 	".qs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Q#"),
-			regexp.MustCompile(`(?m)^((\/{2,3})?\s*(namespace|operation)\b)`),
+			regex.MustCompileRuby(`^((\/{2,3})?\s*(namespace|operation)\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Qt Script"),
-			regexp.MustCompile(`(?m)(\w+\.prototype\.\w+|===|\bvar\b)`),
+			regex.MustCompileRuby(`(\w+\.prototype\.\w+|===|\bvar\b)`),
 		),
 	},
 	".r": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Rebol"),
-			regexp.MustCompile(`(?m)(?i:\bRebol\b)`),
+			regex.MustCompileRuby(`(?i:\bRebol\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("R"),
-			regexp.MustCompile(`(?m)<-|^\s*#`),
+			regex.MustCompileRuby(`<-|^\s*#`),
 		),
 	},
 	".re": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Reason"),
-			regexp.MustCompile(`(?m)^\s*module\s+type\s|^\s*(?:include|open)\s+\w+\s*;\s*$|^\s*let\s+(?:module\s\w+\s*=\s*{|\w+:\s+.*=.*;\s*$)`),
+			regex.MustCompileRuby(`^\s*module\s+type\s|^\s*(?:include|open)\s+\w+\s*;\s*$|^\s*let\s+(?:module\s\w+\s*=\s*{|\w+:\s+.*=.*;\s*$)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("C++"),
-			regexp.MustCompile(`(?m)^\s*#(?:(?:if|ifdef|define|pragma)\s+\w|\s*include\s+<[^>]+>)|^\s*template\s*<`),
+			regex.MustCompileRuby(`^\s*#(?:(?:if|ifdef|define|pragma)\s+\w|\s*include\s+<[^>]+>)|^\s*template\s*<`),
 		),
 	},
 	".res": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("ReScript"),
-			regexp.MustCompile(`(?m)^\s*(let|module|type)\s+\w*\s+=\s+|^\s*(?:include|open)\s+\w+\s*$`),
+			regex.MustCompileRuby(`^\s*(let|module|type)\s+\w*\s+=\s+|^\s*(?:include|open)\s+\w+\s*$`),
 		),
 	},
 	".rno": &Heuristics{
 		rule.Or(
+			rule.MatchingLanguages("RUNOFF"),
+			regex.MustCompileRuby(`(?i:^\.!|^\f|\f$|^\.end lit(?:eral)?\b|^\.[a-zA-Z].*?;\.[a-zA-Z](?:[; \t])|\^\*[^\s*][^*]*\\\*(?=$|\s)|^\.c;[ \t]*\w+)`),
+		),
+		rule.Or(
 			rule.MatchingLanguages("Roff"),
-			regexp.MustCompile(`(?m)^\.\\" `),
+			regex.MustCompileRuby(`^\.\\" `),
 		),
 	},
 	".rpy": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Python"),
-			regexp.MustCompile(`(?m)(?m:^(import|from|class|def)\s)`),
+			regex.MustCompileRuby(`(?m:^(import|from|class|def)\s)`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Ren'Py"),
@@ -1369,55 +1389,59 @@ var ContentHeuristics = map[string]*Heuristics{
 	".rs": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Rust"),
-			regexp.MustCompile(`(?m)^(use |fn |mod |pub |macro_rules|impl|#!?\[)`),
+			regex.MustCompileRuby(`^(use |fn |mod |pub |macro_rules|impl|#!?\[)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("RenderScript"),
-			regexp.MustCompile(`(?m)#include|#pragma\s+(rs|version)|__attribute__`),
+			regex.MustCompileRuby(`#include|#pragma\s+(rs|version)|__attribute__`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)^\s*<\?xml`),
+			regex.MustCompileRuby(`^\s*<\?xml`),
 		),
 	},
 	".s": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Motorola 68K Assembly"),
-			regexp.MustCompile(`(?m)(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
+			regex.MustCompileRuby(`(?im)\bmoveq(?:\.l)?\s+#(?:\$-?[0-9a-f]{1,3}|%[0-1]{1,8}|-?[0-9]{1,3}),\s*d[0-7]\b|(?im)^\s*move(?:\.[bwl])?\s+(?:sr|usp),\s*[^\s]+|(?im)^\s*move\.[bwl]\s+.*\b[ad]\d|(?im)^\s*movem\.[bwl]\b|(?im)^\s*move[mp](?:\.[wl])?\b|(?im)^\s*btst\b|(?im)^\s*dbra\b`),
 		),
 	},
 	".sc": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("SuperCollider"),
-			regexp.MustCompile(`(?m)(?i:\^(this|super)\.|^\s*~\w+\s*=\.)`),
+			regex.MustCompileRuby(`(?i:\^(this|super)\.|^\s*~\w+\s*=\.)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Scala"),
-			regexp.MustCompile(`(?m)(^\s*import (scala|java)\.|^\s*class\b)`),
+			regex.MustCompileRuby(`(^\s*import (scala|java)\.|^\s*class\b)`),
 		),
 	},
 	".sol": &Heuristics{
 		rule.Or(
+			rule.MatchingLanguages("Solidity"),
+			regex.MustCompileRuby(`\bpragma\s+solidity\b|\b(?:abstract\s+)?contract\s+(?!\d)[a-zA-Z0-9$_]+(?:\s+is\s+(?:[a-zA-Z0-9$_][^\{]*?)?)?\s*\{`),
+		),
+		rule.Or(
 			rule.MatchingLanguages("Gerber Image"),
-			regexp.MustCompile(`(?m)^[DGMT][0-9]{2}\*\r?\n`),
+			regex.MustCompileRuby(`^[DGMT][0-9]{2}\*\r?\n`),
 		),
 	},
 	".sql": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("PLpgSQL"),
-			regexp.MustCompile(`(?m)(?i:^\\i\b|AS\s+\$\$|LANGUAGE\s+'?plpgsql'?|BEGIN(\s+WORK)?\s*;)`),
+			regex.MustCompileRuby(`(?i:^\\i\b|AS\s+\$\$|LANGUAGE\s+'?plpgsql'?|BEGIN(\s+WORK)?\s*;)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("SQLPL"),
-			regexp.MustCompile(`(?m)(?i:ALTER\s+MODULE|MODE\s+DB2SQL|\bSYS(CAT|PROC)\.|ASSOCIATE\s+RESULT\s+SET|\bEND!\s*$)`),
+			regex.MustCompileRuby(`(?i:ALTER\s+MODULE|MODE\s+DB2SQL|\bSYS(CAT|PROC)\.|ASSOCIATE\s+RESULT\s+SET|\bEND!\s*$)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("PLSQL"),
-			regexp.MustCompile(`(?m)(?i:\$\$PLSQL_|XMLTYPE|systimestamp|\.nextval|CONNECT\s+BY|AUTHID\s+(DEFINER|CURRENT_USER)|constructor\W+function)`),
+			regex.MustCompileRuby(`(?i:\$\$PLSQL_|XMLTYPE|systimestamp|\.nextval|CONNECT\s+BY|AUTHID\s+(DEFINER|CURRENT_USER)|constructor\W+function)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("TSQL"),
-			regexp.MustCompile(`(?m)(?i:^\s*GO\b|BEGIN(\s+TRY|\s+CATCH)|OUTPUT\s+INSERTED|DECLARE\s+@|\[dbo\])`),
+			regex.MustCompileRuby(`(?i:^\s*GO\b|BEGIN(\s+TRY|\s+CATCH)|OUTPUT\s+INSERTED|DECLARE\s+@|\[dbo\])`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("SQL"),
@@ -1426,43 +1450,47 @@ var ContentHeuristics = map[string]*Heuristics{
 	".srt": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("SubRip Text"),
-			regexp.MustCompile(`(?m)^(\d{2}:\d{2}:\d{2},\d{3})\s*(-->)\s*(\d{2}:\d{2}:\d{2},\d{3})$`),
+			regex.MustCompileRuby(`^(\d{2}:\d{2}:\d{2},\d{3})\s*(-->)\s*(\d{2}:\d{2}:\d{2},\d{3})$`),
 		),
 	},
 	".st": &Heuristics{
 		rule.Or(
+			rule.MatchingLanguages("StringTemplate"),
+			regex.MustCompileRuby(`\$\w+[($]|(.)!\s*.+?\s*!\1|<!\s*.+?\s*!>|\[!\s*.+?\s*!\]|\{!\s*.+?\s*!\}`),
+		),
+		rule.Or(
 			rule.MatchingLanguages("Smalltalk"),
-			regexp.MustCompile(`(?m)\A\s*[\[{(^"'\w#]|[a-zA-Z_]\w*\s*:=\s*[a-zA-Z_]\w*|class\s*>>\s*[a-zA-Z_]\w*|^[a-zA-Z_]\w*\s+[a-zA-Z_]\w*:|^Class\s*{|if(?:True|False):\s*\[`),
+			regex.MustCompileRuby(`\A\s*[\[{(^"'\w#]|[a-zA-Z_]\w*\s*:=\s*[a-zA-Z_]\w*|class\s*>>\s*[a-zA-Z_]\w*|^[a-zA-Z_]\w*\s+[a-zA-Z_]\w*:|^Class\s*{|if(?:True|False):\s*\[`),
 		),
 	},
 	".t": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Perl"),
-			regexp.MustCompile(`(?m)\buse\s+(?:strict\b|v?5\.)`),
+			regex.MustCompileRuby(`\buse\s+(?:strict\b|v?5\.)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Raku"),
-			regexp.MustCompile(`(?m)^\s*(?:use\s+v6\b|\bmodule\b|\bmy\s+class\b)`),
+			regex.MustCompileRuby(`^\s*(?:use\s+v6\b|\bmodule\b|\bmy\s+class\b)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Turing"),
-			regexp.MustCompile(`(?m)^\s*%[ \t]+|^\s*var\s+\w+(\s*:\s*\w+)?\s*:=\s*\w+`),
+			regex.MustCompileRuby(`^\s*%[ \t]+|^\s*var\s+\w+(\s*:\s*\w+)?\s*:=\s*\w+`),
 		),
 	},
 	".toc": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("World of Warcraft Addon Data"),
-			regexp.MustCompile(`(?m)^## |@no-lib-strip@`),
+			regex.MustCompileRuby(`^## |@no-lib-strip@`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("TeX"),
-			regexp.MustCompile(`(?m)^\\(contentsline|defcounter|beamer|boolfalse)`),
+			regex.MustCompileRuby(`^\\(contentsline|defcounter|beamer|boolfalse)`),
 		),
 	},
 	".ts": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)<TS\b`),
+			regex.MustCompileRuby(`<TS\b`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("TypeScript"),
@@ -1471,7 +1499,7 @@ var ContentHeuristics = map[string]*Heuristics{
 	".tst": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("GAP"),
-			regexp.MustCompile(`(?m)gap> `),
+			regex.MustCompileRuby(`gap> `),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Scilab"),
@@ -1480,14 +1508,18 @@ var ContentHeuristics = map[string]*Heuristics{
 	".tsx": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("TSX"),
-			regexp.MustCompile(`(?m)^\s*(import.+(from\s+|require\()['"]react|\/\/\/\s*<reference\s)`),
+			regex.MustCompileRuby(`^\s*(import.+(from\s+|require\()['"]react|\/\/\/\s*<reference\s)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("XML"),
-			regexp.MustCompile(`(?m)(?i:^\s*<\?xml\s+version)`),
+			regex.MustCompileRuby(`(?i:^\s*<\?xml\s+version)`),
 		),
 	},
 	".txt": &Heuristics{
+		rule.Or(
+			rule.MatchingLanguages("Vim Help File"),
+			regex.MustCompileRuby(`(?:(?:^|[ \t])(?:vi|Vi(?=m))(?:m[<=>]?[0-9]+|m)?|[ \t]ex)(?=:(?=[ \t]*set?[ \t][^\r\n:]+:)|:(?![ \t]*set?[ \t]))(?:(?:[ \t]*:[ \t]*|[ \t])\w*(?:[ \t]*=(?:[^\\\s]|\\.)*)?)*[ \t:](?:filetype|ft|syntax)[ \t]*=(help)(?=$|\s|:)`),
+		),
 		rule.Always(
 			rule.MatchingLanguages("Text"),
 		),
@@ -1495,21 +1527,21 @@ var ContentHeuristics = map[string]*Heuristics{
 	".v": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Coq"),
-			regexp.MustCompile(`(?m)(?:^|\s)(?:Proof|Qed)\.(?:$|\s)|(?:^|\s)Require[ \t]+(Import|Export)\s`),
+			regex.MustCompileRuby(`(?:^|\s)(?:Proof|Qed)\.(?:$|\s)|(?:^|\s)Require[ \t]+(Import|Export)\s`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Verilog"),
-			regexp.MustCompile(`(?m)^[ \t]*module\s+[^\s()]+\s+\#?\(|^[ \t]*`+"`"+`(?:define|ifdef|ifndef|include|timescale)|^[ \t]*always[ \t]+@|^[ \t]*initial[ \t]+(begin|@)`),
+			regex.MustCompileRuby(`^[ \t]*module\s+[^\s()]+\s+\#?\(|^[ \t]*`+"`"+`(?:define|ifdef|ifndef|include|timescale)|^[ \t]*always[ \t]+@|^[ \t]*initial[ \t]+(begin|@)`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("V"),
-			regexp.MustCompile(`(?m)\$(?:if|else)[ \t]|^[ \t]*fn\s+[^\s()]+\(.*?\).*?\{|^[ \t]*for\s*\{`),
+			regex.MustCompileRuby(`\$(?:if|else)[ \t]|^[ \t]*fn\s+[^\s()]+\(.*?\).*?\{|^[ \t]*for\s*\{`),
 		),
 	},
 	".vba": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("Vim script"),
-			regexp.MustCompile(`(?m)^UseVimball`),
+			regex.MustCompileRuby(`^UseVimball`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("VBA"),
@@ -1518,35 +1550,35 @@ var ContentHeuristics = map[string]*Heuristics{
 	".w": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("OpenEdge ABL"),
-			regexp.MustCompile(`(?m)&ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS`),
+			regex.MustCompileRuby(`&ANALYZE-SUSPEND _UIB-CODE-BLOCK _CUSTOM _DEFINITIONS`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("CWeb"),
-			regexp.MustCompile(`(?m)^@(<|\w+\.)`),
+			regex.MustCompileRuby(`^@(<|\w+\.)`),
 		),
 	},
 	".x": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("DirectX 3D File"),
-			regexp.MustCompile(`(?m)^xof 030(2|3)(?:txt|bin|tzip|bzip)\b`),
+			regex.MustCompileRuby(`^xof 030(2|3)(?:txt|bin|tzip|bzip)\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("RPC"),
-			regexp.MustCompile(`(?m)\b(program|version)\s+\w+\s*{|\bunion\s+\w+\s+switch\s*\(`),
+			regex.MustCompileRuby(`\b(program|version)\s+\w+\s*{|\bunion\s+\w+\s+switch\s*\(`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Logos"),
-			regexp.MustCompile(`(?m)^%(end|ctor|hook|group)\b`),
+			regex.MustCompileRuby(`^%(end|ctor|hook|group)\b`),
 		),
 		rule.Or(
 			rule.MatchingLanguages("Linker Script"),
-			regexp.MustCompile(`(?m)OUTPUT_ARCH\(|OUTPUT_FORMAT\(|SECTIONS`),
+			regex.MustCompileRuby(`OUTPUT_ARCH\(|OUTPUT_FORMAT\(|SECTIONS`),
 		),
 	},
 	".yy": &Heuristics{
 		rule.Or(
 			rule.MatchingLanguages("JSON"),
-			regexp.MustCompile(`(?m)\"modelName\"\:\s*\"GM`),
+			regex.MustCompileRuby(`\"modelName\"\:\s*\"GM`),
 		),
 		rule.Always(
 			rule.MatchingLanguages("Yacc"),

--- a/regex/oniguruma.go
+++ b/regex/oniguruma.go
@@ -1,3 +1,4 @@
+//go:build oniguruma
 // +build oniguruma
 
 package regex
@@ -7,6 +8,13 @@ import (
 )
 
 type EnryRegexp = *rubex.Regexp
+
+var Name = "oniguruma"
+
+// MustCompileRuby same as MustCompile.
+func MustCompileRuby(str string) EnryRegexp {
+	return MustCompile(str)
+}
 
 func MustCompile(str string) EnryRegexp {
 	return rubex.MustCompileASCII(str)

--- a/regex/standard.go
+++ b/regex/standard.go
@@ -1,12 +1,30 @@
+//go:build !oniguruma
 // +build !oniguruma
 
 package regex
 
 import (
 	"regexp"
+	"strings"
 )
 
 type EnryRegexp = *regexp.Regexp
+
+var Name = "standard"
+
+const multilinePrefix = "(?m)"
+
+// MustCompileRuby returns a new EnryRegexp based on the given Ruby regexp, if
+// the regexp is not supported by the standard library regexp engine, returns a
+// EnryRegexp(nil). If supported it compiles the regexp converting it in a
+// multiline regexp.
+func MustCompileRuby(str string) EnryRegexp {
+	if isUnsupportedRegexpSyntax(str) {
+		return nil
+	}
+
+	return regexp.MustCompile(convertToValidRegexp(str))
+}
 
 func MustCompile(str string) EnryRegexp {
 	return regexp.MustCompile(str)
@@ -14,4 +32,24 @@ func MustCompile(str string) EnryRegexp {
 
 func QuoteMeta(s string) string {
 	return regexp.QuoteMeta(s)
+}
+
+// isUnsupportedRegexpSyntax filters regexp syntax that is not supported by RE2.
+// In particular, we stumbled up on usage of next cases:
+// - lookbehind & lookahead
+// - named & numbered capturing group/after text matching
+// - backreference
+// - possessive quantifier
+// For referece on supported syntax see https://github.com/google/re2/wiki/Syntax
+func isUnsupportedRegexpSyntax(reg string) bool {
+	return strings.Contains(reg, `(?<`) || strings.Contains(reg, `(?=`) || strings.Contains(reg, `(?!`) ||
+		strings.Contains(reg, `\1`) || strings.Contains(reg, `*+`) ||
+		// See https://github.com/github/linguist/pull/4243#discussion_r246105067
+		(strings.HasPrefix(reg, multilinePrefix+`/`) && strings.HasSuffix(reg, `/`))
+}
+
+// convertToValidRegexp converts Ruby regexp syntaxt to RE2 equivalent.
+// Does not work with Ruby regexp literals.
+func convertToValidRegexp(rubyRegexp string) string {
+	return multilinePrefix + rubyRegexp
 }

--- a/regex/standard_test.go
+++ b/regex/standard_test.go
@@ -1,0 +1,20 @@
+//go:build !oniguruma
+// +build !oniguruma
+
+package regex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMustCompileRuby(t *testing.T) {
+	re := MustCompileRuby(`a`)
+	assert.Equal(t, "(?m)a", re.String())
+}
+
+func TestMustCompileRuby_NotSupported(t *testing.T) {
+	re := MustCompileRuby(`\A(?=\w{6,10}\z)`)
+	assert.Equal(t, EnryRegexp(nil), re)
+}

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,6 @@ package enry
 import (
 	"bytes"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -63,7 +62,7 @@ func IsDotFile(path string) bool {
 	return strings.HasPrefix(base, ".") && base != "."
 }
 
-var isVendorRegExp *regexp.Regexp
+var isVendorRegExp regex.EnryRegexp
 
 // IsVendor returns whether or not path is a vendor path.
 func IsVendor(path string) bool {
@@ -242,5 +241,5 @@ func init() {
 	sb.WriteString(")")
 
 	// Compile the whole thing as the isVendorRegExp
-	isVendorRegExp = regexp.MustCompile(sb.String())
+	isVendorRegExp = regex.MustCompile(sb.String())
 }


### PR DESCRIPTION
This PR enables the support of all the non-support heuristics due to the go regexp engine.

- Exposes the original regular expressions to the `regex` package.
- The regex package now handles the conversions of the Ruby regular expression to the go-ish version.
- The heuristics rules now support nil regular expressions since some of the heuristics can't compile using the standard library.

I added some tests using the linguist fixtures and passes all the fixtures (using onigurama).