### PR TITLE
Test: update language name comparison

### DIFF
--- a/common_test.go
+++ b/common_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-enry/go-enry/v2/data"
@@ -259,7 +260,10 @@ func (s *EnryTestSuite) TestGetLanguagesByFilename() {
 
 	for _, test := range tests {
 		languages := GetLanguagesByFilename(test.filename, test.content, test.candidates)
-		assert.Equal(s.T(), test.expected, languages, fmt.Sprintf("%v: languages = %v, expected: %v", test.name, languages, test.expected))
+		assert.Equal(s.T(), len(test.expected), len(languages), fmt.Sprintf("%v: number of languages = %v, expected: %v", test.name, len(languages), len(test.expected)))
+		for i := range languages { // case-insensitive name comparison
+			assert.True(s.T(), strings.EqualFold(test.expected[i], languages[i]), fmt.Sprintf("%v: languages = %v, expected: %v", test.name, languages, test.expected))
+		}
 	}
 }
 

--- a/common_test.go
+++ b/common_test.go
@@ -252,7 +252,7 @@ func (s *EnryTestSuite) TestGetLanguagesByFilename() {
 		{name: "TestGetLanguagesByFilename_4", filename: "Makefile.frag", expected: []string{"Makefile"}},
 		{name: "TestGetLanguagesByFilename_5", filename: "makefile", expected: []string{"Makefile"}},
 		{name: "TestGetLanguagesByFilename_6", filename: "Vagrantfile", expected: []string{"Ruby"}},
-		{name: "TestGetLanguagesByFilename_7", filename: "_vimrc", expected: []string{"Vim script"}},
+		{name: "TestGetLanguagesByFilename_7", filename: "_vimrc", expected: []string{"Vim Script"}},
 		{name: "TestGetLanguagesByFilename_8", filename: "pom.xml", expected: []string{"Maven POM"}},
 		{name: "TestGetLanguagesByFilename_9", filename: "", expected: nil},
 	}


### PR DESCRIPTION
Linguist to v7.17.0 changed case in language name, so some tests are broken in #66  as our fixtures hard-code the names.

Most probably, we should rather have a case-insensitive language name comparison here instead (as test will fail \w older Linguist versions otherwise).