### PR TITLE
Auto-update Linguist version in README.md

### DIFF
--- a/.github/workflows/sync-linguist.yml
+++ b/.github/workflows/sync-linguist.yml
@@ -73,9 +73,13 @@ jobs:
         echo "::set-output name=short_commit::${commit::8}"
 
         cd ..
-    - name: Update Linguist commit
+    - name: Update Linguist information
       run: |
+        set -euo pipefail
+        IFS=$'\n\t'
+
         sed --in-place --regexp-extended 's/(commit[[:space:]]+=[[:space:]])("[a-f0-9]{40}")/\1"${{ steps.linguist-release.outputs.commit }}"/' internal/code-generator/generator/generator_test.go
+        sed --in-place --regexp-extended 's/version \*\*v.+\*\*\./version \*\*${{ steps.linguist-release.outputs.linguist_version }}\*\*\./' README.md
     - name: Generate code
       run: make code-generate
     - name: Commit changes


### PR DESCRIPTION
This uses `sed` to update the Linguist version in the README.md.

Example change from my test PR: https://github.com/look/go-enry/pull/7/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5