### PR TITLE
Add poetry.lock to generated files

### DIFF
--- a/data/generated.go
+++ b/data/generated.go
@@ -93,6 +93,9 @@ var GeneratedCodeNameMatchers = []GeneratedCodeNameMatcher{
 
 	// GraphQL relay
 	nameContains("__generated__/"),
+
+	// Poetry lock
+	nameEndsWith("poetry.lock"),
 }
 
 // GeneratedCodeMatcher checks whether the file with the given data is

--- a/utils_test.go
+++ b/utils_test.go
@@ -370,6 +370,9 @@ func TestIsGenerated(t *testing.T) {
 		{"Generated/Haxe/Main.java", true, true},
 		{"Generated/Haxe/Main.cs", true, true},
 		{"Generated/Haxe/Main.php", true, true},
+
+		//Poetry lock file
+		{"Dummy/poetry.lock", false, true},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
`poetry.lock` is a generated file by the python poetry package manager, see https://python-poetry.org/docs/basic-usage/ for references.