### PR TITLE
Fix IsVendor() regex generation

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -213,23 +213,23 @@ func init() {
 	sb := &strings.Builder{}
 
 	// Start with group 1 - those that started with `^`
-	sb.WriteString("(?:^(?:")
+	sb.WriteString("(?:^(?:(?:")
 	sb.WriteString(caretStrings[0])
 	for _, matcher := range caretStrings[1:] {
 		sb.WriteString(")|(?:")
 		sb.WriteString(matcher)
 	}
-	sb.WriteString("))")
+	sb.WriteString(")))")
 	sb.WriteString("|")
 
 	// Now add group 2 - those that started with `(^|/)`
-	sb.WriteString("(?:(?:^|/)(?:")
+	sb.WriteString("(?:(?:^|/)(?:(?:")
 	sb.WriteString(caretSegmentStrings[0])
 	for _, matcher := range caretSegmentStrings[1:] {
 		sb.WriteString(")|(?:")
 		sb.WriteString(matcher)
 	}
-	sb.WriteString("))")
+	sb.WriteString(")))")
 	sb.WriteString("|")
 
 	// Finally add the rest

--- a/utils_test.go
+++ b/utils_test.go
@@ -17,6 +17,7 @@ func TestIsVendor(t *testing.T) {
 		expected bool
 	}{
 		{"cache/", true},
+		{"something_cache/", false},
 		{"random/cache/", true},
 		{"cache", false},
 		{"dependencies/", true},
@@ -27,6 +28,7 @@ func TestIsVendor(t *testing.T) {
 		{"random/dist/", true},
 		{"random/dist", false},
 		{"deps/", true},
+		{"foodeps/", false},
 		{"configure", true},
 		{"a/configure", true},
 		{"config.guess", true},
@@ -43,6 +45,7 @@ func TestIsVendor(t *testing.T) {
 		{"foo/bar/MochiKit.js", true},
 		{"foo/bar/dojo.js", true},
 		{"foo/env/whatever", true},
+		{"some/python/venv/", false},
 		{"foo/.imageset/bar", true},
 		{"Vagrantfile", true},
 	}


### PR DESCRIPTION
The regex generation introduced by
https://github.com/go-enry/go-enry/commit/20726a1de3cdff1d64bf0a6e5f6e2475a2c96913
had a subtle but important bug in it. In particular the ^ and ^|/
prefixes were only applied to the first regex in the OR'd groupings and
not every regex in the grouping.

We fix this by wrapping each of those OR'd groups in a new non capturing
group to ensure the prefix applies to every entry in the OR'd listing.

Additionally we add three new quick tests of IsVendor to guard against
this regression in the future.

This fixes https://github.com/go-enry/go-enry/issues/135