### PR TITLE
Refactoring tests

### DIFF
--- a/common.go
+++ b/common.go
@@ -38,7 +38,7 @@ var defaultClassifier classifier = &naiveBayes{
 }
 
 // GetLanguage applies a sequence of strategies based on the given filename and content
-// to find out the most probably language to return.
+// to find out the most probable language to return.
 func GetLanguage(filename string, content []byte) (language string) {
 	languages := GetLanguages(filename, content)
 	return firstLanguage(languages)
@@ -508,28 +508,6 @@ func GetLanguageExtensions(language string) []string {
 	return data.ExtensionsByLanguage[language]
 }
 
-// GetLanguageID returns the ID for the language. IDs are assigned by GitHub.
-// The input must be the canonical language name. Aliases are not supported.
-//
-// NOTE: The zero value (0) is a valid language ID, so this API mimics the Go
-// map API. Use the second return value to check if the language was found.
-func GetLanguageID(language string) (int, bool) {
-	id, ok := data.IDByLanguage[language]
-	return id, ok
-}
-
-// Type represent language's type. Either data, programming, markup, prose, or unknown.
-type Type int
-
-// Type's values.
-const (
-	Unknown     Type = Type(data.TypeUnknown)
-	Data             = Type(data.TypeData)
-	Programming      = Type(data.TypeProgramming)
-	Markup           = Type(data.TypeMarkup)
-	Prose            = Type(data.TypeProse)
-)
-
 // GetLanguageType returns the type of the given language.
 func GetLanguageType(language string) (langType Type) {
 	intType, ok := data.LanguagesType[language]
@@ -538,6 +516,15 @@ func GetLanguageType(language string) (langType Type) {
 		langType = Unknown
 	}
 	return langType
+}
+
+// GetLanguageGroup returns language group or empty string if language does not have group.
+func GetLanguageGroup(language string) string {
+	if group, ok := data.LanguagesGroup[language]; ok {
+		return group
+	}
+
+	return ""
 }
 
 // GetLanguageByAlias returns either the language related to the given alias and ok set to true
@@ -551,13 +538,14 @@ func GetLanguageByAlias(alias string) (lang string, ok bool) {
 	return
 }
 
-// GetLanguageGroup returns language group or empty string if language does not have group.
-func GetLanguageGroup(language string) string {
-	if group, ok := data.LanguagesGroup[language]; ok {
-		return group
-	}
-
-	return ""
+// GetLanguageID returns the ID for the language. IDs are assigned by GitHub.
+// The input must be the canonical language name. Aliases are not supported.
+//
+// NOTE: The zero value (0) is a valid language ID, so this API mimics the Go
+// map API. Use the second return value to check if the language was found.
+func GetLanguageID(language string) (int, bool) {
+	id, ok := data.IDByLanguage[language]
+	return id, ok
 }
 
 // GetLanguageInfo returns the LanguageInfo for a given language name, or an error if not found.

--- a/common_test.go
+++ b/common_test.go
@@ -32,7 +32,7 @@ func maybeCloneLinguist() (string, bool, error) {
 		}
 
 		isCleanupNeeded = true
-		cmd := exec.Command("git", "clone", linguistURL, linguistTmpDir)
+		cmd := exec.Command("git", "clone", "--depth", "100", linguistURL, linguistTmpDir)
 		if err := cmd.Run(); err != nil {
 			return linguistTmpDir, isCleanupNeeded, err
 		}

--- a/common_test.go
+++ b/common_test.go
@@ -78,7 +78,7 @@ func (s *enryBaseTestSuite) SetupSuite() {
 func (s *enryBaseTestSuite) TearDownSuite() {
 	if s.isCleanupNeeded {
 		err := os.RemoveAll(s.tmpLinguistDir)
-		assert.NoError(s.T(), err)
+		require.NoError(s.T(), err)
 	}
 }
 

--- a/common_test.go
+++ b/common_test.go
@@ -19,6 +19,7 @@ import (
 const linguistURL = "https://github.com/github/linguist.git"
 const linguistClonedEnvVar = "ENRY_TEST_REPO"
 
+// not a part of the test Suite as benchmark does not use testify
 func maybeCloneLinguist() (string, bool, error) {
 	var err error
 	linguistTmpDir := os.Getenv(linguistClonedEnvVar)
@@ -57,7 +58,7 @@ func maybeCloneLinguist() (string, bool, error) {
 	return linguistTmpDir, isCleanupNeeded, nil
 }
 
-type EnryTestSuite struct {
+type enryBaseTestSuite struct {
 	suite.Suite
 	tmpLinguistDir  string
 	isCleanupNeeded bool
@@ -65,7 +66,31 @@ type EnryTestSuite struct {
 	testFixturesDir string
 }
 
-func (s *EnryTestSuite) TestRegexpEdgeCases() {
+func (s *enryBaseTestSuite) SetupSuite() {
+	var err error
+	s.tmpLinguistDir, s.isCleanupNeeded, err = maybeCloneLinguist()
+	require.NoError(s.T(), err)
+
+	s.samplesDir = filepath.Join(s.tmpLinguistDir, "samples")
+	s.testFixturesDir = filepath.Join(s.tmpLinguistDir, "test", "fixtures")
+}
+
+func (s *enryBaseTestSuite) TearDownSuite() {
+	if s.isCleanupNeeded {
+		err := os.RemoveAll(s.tmpLinguistDir)
+		assert.NoError(s.T(), err)
+	}
+}
+
+type enryTestSuite struct {
+	enryBaseTestSuite
+}
+
+func Test_EnryTestSuite(t *testing.T) {
+	suite.Run(t, new(enryTestSuite))
+}
+
+func (s *enryTestSuite) TestRegexpEdgeCases() {
 	var regexpEdgeCases = []struct {
 		lang     string
 		filename string
@@ -92,27 +117,7 @@ func (s *EnryTestSuite) TestRegexpEdgeCases() {
 	}
 }
 
-func Test_EnryTestSuite(t *testing.T) {
-	suite.Run(t, new(EnryTestSuite))
-}
-
-func (s *EnryTestSuite) SetupSuite() {
-	var err error
-	s.tmpLinguistDir, s.isCleanupNeeded, err = maybeCloneLinguist()
-	assert.NoError(s.T(), err)
-
-	s.samplesDir = filepath.Join(s.tmpLinguistDir, "samples")
-	s.testFixturesDir = filepath.Join(s.tmpLinguistDir, "test", "fixtures")
-}
-
-func (s *EnryTestSuite) TearDownSuite() {
-	if s.isCleanupNeeded {
-		err := os.RemoveAll(s.tmpLinguistDir)
-		assert.NoError(s.T(), err)
-	}
-}
-
-func (s *EnryTestSuite) TestGetLanguage() {
+func (s *enryTestSuite) TestGetLanguage() {
 	tests := []struct {
 		name     string
 		filename string
@@ -134,7 +139,7 @@ func (s *EnryTestSuite) TestGetLanguage() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguages() {
+func (s *enryTestSuite) TestGetLanguages() {
 	tests := []struct {
 		name     string
 		filename string
@@ -166,7 +171,7 @@ func (s *EnryTestSuite) TestGetLanguages() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesByModelineLinguist() {
+func (s *enryTestSuite) TestGetLanguagesByModelineLinguist() {
 	var modelinesDir = filepath.Join(s.tmpLinguistDir, "test", "fixtures", "Data", "Modelines")
 
 	tests := []struct {
@@ -226,7 +231,7 @@ func (s *EnryTestSuite) TestGetLanguagesByModelineLinguist() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesByModeline() {
+func (s *enryTestSuite) TestGetLanguagesByModeline() {
 	const (
 		wrongVim  = `# vim: set syntax=ruby ft  =python filetype=perl :`
 		rightVim  = `/* vim: set syntax=python ft   =python filetype=python */`
@@ -253,7 +258,7 @@ func (s *EnryTestSuite) TestGetLanguagesByModeline() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesByFilename() {
+func (s *enryTestSuite) TestGetLanguagesByFilename() {
 	tests := []struct {
 		name       string
 		filename   string
@@ -281,7 +286,7 @@ func (s *EnryTestSuite) TestGetLanguagesByFilename() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesByShebang() {
+func (s *enryTestSuite) TestGetLanguagesByShebang() {
 	const (
 		multilineExecHack = `#!/bin/sh
 # Next line is comment in Tcl, but not in sh... \
@@ -366,7 +371,7 @@ println("The shell script says ",vm.arglist.concat(" "));`
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesByExtension() {
+func (s *enryTestSuite) TestGetLanguagesByExtension() {
 	tests := []struct {
 		name       string
 		filename   string
@@ -387,7 +392,7 @@ func (s *EnryTestSuite) TestGetLanguagesByExtension() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesByManpage() {
+func (s *enryTestSuite) TestGetLanguagesByManpage() {
 	tests := []struct {
 		name       string
 		filename   string
@@ -411,7 +416,7 @@ func (s *EnryTestSuite) TestGetLanguagesByManpage() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesByXML() {
+func (s *enryTestSuite) TestGetLanguagesByXML() {
 	tests := []struct {
 		name       string
 		filename   string
@@ -434,7 +439,7 @@ func (s *EnryTestSuite) TestGetLanguagesByXML() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesByClassifier() {
+func (s *enryTestSuite) TestGetLanguagesByClassifier() {
 	test := []struct {
 		name       string
 		filename   string
@@ -471,7 +476,7 @@ func (s *EnryTestSuite) TestGetLanguagesByClassifier() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguagesBySpecificClassifier() {
+func (s *enryTestSuite) TestGetLanguagesBySpecificClassifier() {
 	test := []struct {
 		name       string
 		filename   string
@@ -504,7 +509,7 @@ func (s *EnryTestSuite) TestGetLanguagesBySpecificClassifier() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguageExtensions() {
+func (s *enryTestSuite) TestGetLanguageExtensions() {
 	tests := []struct {
 		name     string
 		language string
@@ -521,7 +526,7 @@ func (s *EnryTestSuite) TestGetLanguageExtensions() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguageType() {
+func (s *enryTestSuite) TestGetLanguageType() {
 	tests := []struct {
 		name     string
 		language string
@@ -544,7 +549,7 @@ func (s *EnryTestSuite) TestGetLanguageType() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguageGroup() {
+func (s *enryTestSuite) TestGetLanguageGroup() {
 	tests := []struct {
 		name     string
 		language string
@@ -562,7 +567,7 @@ func (s *EnryTestSuite) TestGetLanguageGroup() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguageByAlias() {
+func (s *enryTestSuite) TestGetLanguageByAlias() {
 	tests := []struct {
 		name         string
 		alias        string
@@ -588,57 +593,7 @@ func (s *EnryTestSuite) TestGetLanguageByAlias() {
 	}
 }
 
-func (s *EnryTestSuite) TestLinguistCorpus() {
-	const filenamesDir = "filenames"
-	var cornerCases = map[string]bool{
-		"drop_stuff.sql":        true, // https://github.com/src-d/enry/issues/194
-		"textobj-rubyblock.vba": true, // Because of unsupported negative lookahead RE syntax (https://github.com/github/linguist/blob/8083cb5a89cee2d99f5a988f165994d0243f0d1e/lib/linguist/heuristics.yml#L521)
-		// .es and .ice fail heuristics parsing, but do not fail any tests
-	}
-
-	var total, failed, ok, other int
-	var expected string
-	filepath.Walk(s.samplesDir, func(path string, f os.FileInfo, err error) error {
-		if f.IsDir() {
-			if f.Name() != filenamesDir {
-				expected, _ = data.LanguageByAlias(f.Name())
-			}
-
-			return nil
-		}
-
-		filename := filepath.Base(path)
-		content, _ := ioutil.ReadFile(path)
-
-		total++
-		obtained := GetLanguage(filename, content)
-		if obtained == OtherLanguage {
-			obtained = "Other"
-			other++
-		}
-
-		var status string
-		if expected == obtained {
-			status = "ok"
-			ok++
-		} else {
-			status = "failed"
-			failed++
-		}
-
-		if _, ok := cornerCases[filename]; ok {
-			s.T().Logf("\t\t[considered corner case] %s\texpected: %s\tobtained: %s\tstatus: %s\n", filename, expected, obtained, status)
-		} else {
-			assert.Equal(s.T(), expected, obtained, fmt.Sprintf("%s\texpected: %s\tobtained: %s\tstatus: %s\n", filename, expected, obtained, status))
-		}
-
-		return nil
-	})
-
-	s.T().Logf("\t\ttotal files: %d, ok: %d, failed: %d, other: %d\n", total, ok, failed, other)
-}
-
-func (s *EnryTestSuite) TestGetLanguageID() {
+func (s *enryTestSuite) TestGetLanguageID() {
 	tests := []struct {
 		name       string
 		language   string
@@ -661,7 +616,7 @@ func (s *EnryTestSuite) TestGetLanguageID() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguageInfo() {
+func (s *enryTestSuite) TestGetLanguageInfo() {
 	tests := []struct {
 		name       string
 		language   string
@@ -688,7 +643,7 @@ func (s *EnryTestSuite) TestGetLanguageInfo() {
 	}
 }
 
-func (s *EnryTestSuite) TestGetLanguageInfoByID() {
+func (s *enryTestSuite) TestGetLanguageInfoByID() {
 	tests := []struct {
 		name         string
 		id           int

--- a/enry.go
+++ b/enry.go
@@ -14,3 +14,17 @@
 package enry // import "github.com/go-enry/go-enry/v2"
 
 //go:generate make code-generate
+
+import "github.com/go-enry/go-enry/v2/data"
+
+// Type represent language's type. Either data, programming, markup, prose, or unknown.
+type Type int
+
+// Type's values.
+const (
+	Unknown     Type = Type(data.TypeUnknown)
+	Data             = Type(data.TypeData)
+	Programming      = Type(data.TypeProgramming)
+	Markup           = Type(data.TypeMarkup)
+	Prose            = Type(data.TypeProse)
+)

--- a/internal/code-generator/generator/generator_test.go
+++ b/internal/code-generator/generator/generator_test.go
@@ -129,7 +129,7 @@ func (s *GeneratorTestSuite) maybeCloneLinguist() {
 
 		s.T().Logf("Cloning Linguist repo to '%s' as %s was not set\n",
 			s.tmpLinguistDir, linguistClonedEnvVar)
-		cmd := exec.Command("git", "clone", linguistURL, s.tmpLinguistDir)
+		cmd := exec.Command("git", "clone", "--depth", "100", linguistURL, s.tmpLinguistDir)
 		err = cmd.Run()
 		assert.NoError(s.T(), err)
 		s.isCleanupNeeded = true

--- a/internal/code-generator/generator/generator_test.go
+++ b/internal/code-generator/generator/generator_test.go
@@ -97,9 +97,9 @@ var (
 
 type GeneratorTestSuite struct {
 	suite.Suite
-	tmpLinguistDir   string
-	isLinguistCloned bool
-	testCases        []testCase
+	tmpLinguistDir  string
+	isCleanupNeeded bool
+	testCases       []testCase
 }
 
 type testCase struct {
@@ -122,27 +122,31 @@ func Test_GeneratorTestSuite(t *testing.T) {
 func (s *GeneratorTestSuite) maybeCloneLinguist() {
 	var err error
 	s.tmpLinguistDir = os.Getenv(linguistClonedEnvVar)
-	s.isLinguistCloned = s.tmpLinguistDir != ""
-	if !s.isLinguistCloned {
+	isLinguistCloned := s.tmpLinguistDir != ""
+	if !isLinguistCloned {
 		s.tmpLinguistDir, err = ioutil.TempDir("", "linguist-")
 		assert.NoError(s.T(), err)
+
+		s.T().Logf("Cloning Linguist repo to '%s' as %s was not set\n",
+			s.tmpLinguistDir, linguistClonedEnvVar)
 		cmd := exec.Command("git", "clone", linguistURL, s.tmpLinguistDir)
 		err = cmd.Run()
 		assert.NoError(s.T(), err)
-
-		cwd, err := os.Getwd()
-		assert.NoError(s.T(), err)
-
-		err = os.Chdir(s.tmpLinguistDir)
-		assert.NoError(s.T(), err)
-
-		cmd = exec.Command("git", "checkout", commit)
-		err = cmd.Run()
-		assert.NoError(s.T(), err)
-
-		err = os.Chdir(cwd)
-		assert.NoError(s.T(), err)
+		s.isCleanupNeeded = true
 	}
+
+	cwd, err := os.Getwd()
+	assert.NoError(s.T(), err)
+
+	err = os.Chdir(s.tmpLinguistDir)
+	assert.NoError(s.T(), err)
+
+	cmd := exec.Command("git", "checkout", commit)
+	err = cmd.Run()
+	assert.NoError(s.T(), err)
+
+	err = os.Chdir(cwd)
+	assert.NoError(s.T(), err)
 }
 
 func (s *GeneratorTestSuite) SetupSuite() {
@@ -280,11 +284,9 @@ func (s *GeneratorTestSuite) SetupSuite() {
 }
 
 func (s *GeneratorTestSuite) TearDownSuite() {
-	if s.isLinguistCloned {
+	if s.isCleanupNeeded {
 		err := os.RemoveAll(s.tmpLinguistDir)
-		if err != nil {
-			s.T().Logf("Failed to clean up %s after the test.\n", s.tmpLinguistDir)
-		}
+		assert.NoError(s.T(), err)
 	}
 }
 

--- a/internal/code-generator/generator/generator_test.go
+++ b/internal/code-generator/generator/generator_test.go
@@ -125,28 +125,28 @@ func (s *GeneratorTestSuite) maybeCloneLinguist() {
 	isLinguistCloned := s.tmpLinguistDir != ""
 	if !isLinguistCloned {
 		s.tmpLinguistDir, err = ioutil.TempDir("", "linguist-")
-		assert.NoError(s.T(), err)
+		require.NoError(s.T(), err)
 
 		s.T().Logf("Cloning Linguist repo to '%s' as %s was not set\n",
 			s.tmpLinguistDir, linguistClonedEnvVar)
 		cmd := exec.Command("git", "clone", "--depth", "100", linguistURL, s.tmpLinguistDir)
 		err = cmd.Run()
-		assert.NoError(s.T(), err)
+		require.NoError(s.T(), err)
 		s.isCleanupNeeded = true
 	}
 
 	cwd, err := os.Getwd()
-	assert.NoError(s.T(), err)
+	require.NoError(s.T(), err)
 
 	err = os.Chdir(s.tmpLinguistDir)
-	assert.NoError(s.T(), err)
+	require.NoError(s.T(), err)
 
 	cmd := exec.Command("git", "checkout", commit)
 	err = cmd.Run()
-	assert.NoError(s.T(), err)
+	require.NoError(s.T(), err)
 
 	err = os.Chdir(cwd)
-	assert.NoError(s.T(), err)
+	require.NoError(s.T(), err)
 }
 
 func (s *GeneratorTestSuite) SetupSuite() {

--- a/linguist_corpus_test.go
+++ b/linguist_corpus_test.go
@@ -1,0 +1,71 @@
+package enry
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-enry/go-enry/v2/data"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type linguistCorpusSuite struct {
+	enryBaseTestSuite
+}
+
+func Test_EnryOnLinguistCorpus(t *testing.T) {
+	suite.Run(t, new(linguistCorpusSuite))
+}
+
+// First part of the test_blob.rb#test_language
+// https://github.com/github/linguist/blob/59b2d88b2242e6062384e5fb876668cc30ead951/test/test_blob.rb#L258
+func (s *linguistCorpusSuite) TestLinguistSamples() {
+	const filenamesDir = "filenames"
+	var cornerCases = map[string]bool{
+		"drop_stuff.sql":        true, // https://github.com/src-d/enry/issues/194
+		"textobj-rubyblock.vba": true, // Because of unsupported negative lookahead RE syntax (https://github.com/github/linguist/blob/8083cb5a89cee2d99f5a988f165994d0243f0d1e/lib/linguist/heuristics.yml#L521)
+		// .es and .ice fail heuristics parsing, but do not fail any tests
+	}
+
+	var total, failed, ok, other int
+	var expected string
+	filepath.Walk(s.samplesDir, func(path string, f os.FileInfo, err error) error {
+		if f.IsDir() {
+			if f.Name() != filenamesDir {
+				expected, _ = data.LanguageByAlias(f.Name())
+			}
+
+			return nil
+		}
+
+		filename := filepath.Base(path)
+		content, _ := ioutil.ReadFile(path)
+
+		total++
+		obtained := GetLanguage(filename, content)
+		if obtained == OtherLanguage {
+			obtained = "Other"
+			other++
+		}
+
+		var status string
+		if expected == obtained {
+			status = "ok"
+			ok++
+		} else {
+			status = "failed"
+			failed++
+		}
+
+		if _, ok := cornerCases[filename]; ok {
+			s.T().Logf("\t\t[considered corner case] %s\texpected: %s\tobtained: %s\tstatus: %s\n", filename, expected, obtained, status)
+		} else {
+			assert.Equal(s.T(), expected, obtained, fmt.Sprintf("%s\texpected: %s\tobtained: %s\tstatus: %s\n", filename, expected, obtained, status))
+		}
+		return nil
+	})
+	s.T().Logf("\t\ttotal files: %d, ok: %d, failed: %d, other: %d\n", total, ok, failed, other)
+}


### PR DESCRIPTION
Several cosmetic changes
 * API function declarations order follows tests order
 * Linguist lazy loading logic unified & re-used, as much as possible between tests&benchmark
 * Separate test suite extracted for running over Linguist samples/fixtures