### PR TITLE
test: cover GetLanguageByContent confusing edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ To make a guess only based on the content of the file or a text snippet, use
 
 ### By file
 
-The most accurate guess would be one when both, the file name and the content are available:
+The most accurate guess would be when both, a file name and it's content are available:
 
 - `GetLanguagesByContent` only uses file extension and a set of regexp-based content heuristics.
 - `GetLanguages` uses the full set of matching strategies and is expected to be most accurate.

--- a/common_test.go
+++ b/common_test.go
@@ -371,6 +371,25 @@ println("The shell script says ",vm.arglist.concat(" "));`
 	}
 }
 
+func (s *enryTestSuite) TestGetLanguageByContent() {
+	tests := []struct {
+		name     string
+		filename string
+		content  []byte
+		expected string
+	}{
+		{name: "TestGetLanguageByContent_0", filename: "", expected: ""},
+		{name: "TestGetLanguageByContent_1", filename: "foo.cpp", content: []byte("int main() { return 0; }"), expected: ""},                      // as .cpp is unambiguous ¯\_(ツ)_/¯
+		{name: "TestGetLanguageByContent_2", filename: "foo.h", content: []byte("int main() { return 0; }"), expected: "C"},                       // C, as it does not match any of the heuristics for C++ or Objective-C
+		{name: "TestGetLanguageByContent_3", filename: "foo.h", content: []byte("#include <string>\n int main() { return 0; }"), expected: "C++"}, // '#include <string>' matches regex heuristic
+	}
+
+	for _, test := range tests {
+		languages, _ := GetLanguageByContent(test.filename, test.content)
+		assert.Equal(s.T(), test.expected, languages, fmt.Sprintf("%v: languages = %v, expected: %v", test.name, languages, test.expected))
+	}
+}
+
 func (s *enryTestSuite) TestGetLanguagesByExtension() {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
And clarify documentation wording, based on discussion at https://github.com/go-enry/go-enry/issues/145

test plan:
 * go test -run '^Test_EnryTestSuite$' -testify.m '^(TestGetLanguageByContent)$' ./...