### PR TITLE
ci: fix Python profile after ubuntu-latest 20.04->22.04 update

### DIFF
--- a/.github/workflows/pyTest.yml
+++ b/.github/workflows/pyTest.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
Addresses https://github.com/go-enry/go-enry/pull/144#issuecomment-1328810979

Github has changed the ubuntu-latest runner and it does not ship Python 3.6 any more 🤷 

See https://github.com/actions/setup-python/issues/544#issuecomment-1320295576

test plan:
 * CI profile for python is green