### PR TITLE
Fix oniguruma profile on CI

### DIFF
--- a/.github/workflows/goTest.yml
+++ b/.github/workflows/goTest.yml
@@ -47,6 +47,6 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Test
-      run: go test ./...
+      run: go test -tags ${GO_TAGS} ./...
       env:
         GO_TAGS: oniguruma


### PR DESCRIPTION
Somehow, we neglected to pass build tags on CI.

https://github.com/go-enry/go-enry/pull/151#issuecomment-1364740368