### PR TITLE
data: add .markdown for Markdown

### DIFF
--- a/data/extension.go
+++ b/data/extension.go
@@ -656,6 +656,7 @@ var LanguagesByExtension = map[string][]string{
 	".mjml":                {"XML"},
 	".mjs":                 {"JavaScript"},
 	".mk":                  {"Makefile"},
+	".markdown":            {"Markdown"},
 	".mkd":                 {"Markdown"},
 	".mkdn":                {"Markdown"},
 	".mkdown":              {"Markdown"},


### PR DESCRIPTION
I've seen many markdown files in the wild end in `.markdown`. GitHub Linguist [also supports this extension](https://github.com/github/linguist/blob/1345d0122a82119ae01abc366346fc9b022cc444/lib/linguist/languages.yml#L3948-L3973).