### PR TITLE
sync `GeneratedCodeNameMatchers` with Linguist

### DIFF
--- a/data/generated.go
+++ b/data/generated.go
@@ -42,6 +42,9 @@ func nameEndsWith(pattern string) GeneratedCodeNameMatcher {
 // GeneratedCodeNameMatchers are all the matchers that check whether the code
 // is generated based only on the file name.
 var GeneratedCodeNameMatchers = []GeneratedCodeNameMatcher{
+	// IntelliJ IDEA project
+	nameMatches(`(?:^|\/)\.idea\/`),
+
 	// Cocoa pods
 	nameMatches(`(^Pods|\/Pods)\/`),
 
@@ -52,7 +55,7 @@ var GeneratedCodeNameMatchers = []GeneratedCodeNameMatcher{
 	nameMatches(`(?i)\.designer\.(cs|vb)$`),
 
 	// Generated NET specflow feature file
-	nameEndsWith(".feature.cs"),
+	nameMatches(`(?i)\.feature\.cs$`),
 
 	// Node modules
 	nameContains("node_modules/"),
@@ -64,14 +67,29 @@ var GeneratedCodeNameMatchers = []GeneratedCodeNameMatcher{
 	nameEndsWith("Gopkg.lock"),
 	nameEndsWith("glide.lock"),
 
+	// Poetry lock
+	nameEndsWith("poetry.lock"),
+
+	// PDM lock
+	nameEndsWith("pdm.lock"),
+
+	// uv lock
+	nameEndsWith("uv.lock"),
+
 	// Esy lock
 	nameMatches(`(^|\/)(\w+\.)?esy.lock$`),
+
+	// Deno lock
+	nameEndsWith("deno.lock"),
 
 	// NPM shrinkwrap
 	nameEndsWith("npm-shrinkwrap.json"),
 
 	// NPM package lock
 	nameEndsWith("package-lock.json"),
+
+	// pnpm lock
+	nameEndsWith("pnpm-lock.yaml"),
 
 	// Yarn plugnplay
 	nameMatches(`(^|\/)\.pnp\..*$`),
@@ -88,14 +106,32 @@ var GeneratedCodeNameMatchers = []GeneratedCodeNameMatcher{
 	// Cargo lock
 	nameEndsWith("Cargo.lock"),
 
+	// Cargo original file
+	nameEndsWith("Cargo.toml.orig"),
+
+	// Nix flakes lock
+	nameMatches(`(^|\/)flake\.lock$`),
+
+	// Bazel Bzlmod lock
+	nameMatches(`(^|\/)MODULE\.bazel\.lock$`),
+
 	// Pipenv lock
 	nameEndsWith("Pipfile.lock"),
+
+	// Terraform lock
+	nameMatches(`(?:^|\/)\.terraform\.lock\.hcl$`),
 
 	// GraphQL relay
 	nameContains("__generated__/"),
 
-	// Poetry lock
-	nameEndsWith("poetry.lock"),
+	// Delphi interface file
+	nameMatches(`(?i)_tlb\.pas$`),
+
+	// HTML coverage report
+	nameMatches(`(?:^|\/)htmlcov\/`),
+
+	// SQLx query file
+	nameMatches(`(?:^|.*\/)\.sqlx\/query-.+\.json$`),
 }
 
 // GeneratedCodeMatcher checks whether the file with the given data is

--- a/utils_test.go
+++ b/utils_test.go
@@ -289,12 +289,15 @@ func TestIsGenerated(t *testing.T) {
 		//npm shrinkwrap file
 		{"Dummy/npm-shrinkwrap.json", false, true},
 		{"Dummy/package-lock.json", false, true},
-		{"JavaScript/jquery-1.6.1.min.js", true, true},
+
+		//pnpm lockfile
+		{"Dummy/pnpm-lock.yaml", false, true},
 
 		//Yarn Plug'n'Play file
 		{".pnp.js", false, true},
 		{".pnp.cjs", false, true},
 		{".pnp.mjs", false, true},
+		{".pnp.loader.mjs", false, true},
 
 		//Godep saved dependencies
 		{"Godeps/Godeps.json", false, true},
@@ -385,8 +388,54 @@ func TestIsGenerated(t *testing.T) {
 		{"Generated/Haxe/Main.cs", true, true},
 		{"Generated/Haxe/Main.php", true, true},
 
-		//Poetry lock file
-		{"Dummy/poetry.lock", false, true},
+		//Cargo
+		{"TOML/filenames/Cargo.toml.orig", false, true},
+
+		//poetry
+		{"TOML/filenames/poetry.lock", false, true},
+
+		//pdm
+		{"TOML/filenames/pdm.lock", false, true},
+
+		//uv
+		{"TOML/filenames/uv.lock", false, true},
+
+		//coverage.py `coverage html` output
+		{"htmlcov/index.html", false, true},
+		{"htmlcov/coverage_html.js", false, true},
+		{"htmlcov/style.css", false, true},
+		{"htmlcov/status.json", false, true},
+		{"Dummy/htmlcov/index.html", false, true},
+		{"Dummy/htmlcov/coverage_html.js", false, true},
+		{"Dummy/htmlcov/style.css", false, true},
+		{"Dummy/htmlcov/status.json", false, true},
+
+		//Jest snapshots (https://github.com/github-linguist/linguist/pull/3579)
+		{"Jest Snapshot/css.test.tsx.snap", false, false},
+
+		//Yarn lockfiles (https://github.com/github-linguist/linguist/pull/4459)
+		{"YAML/filenames/yarn.lock", false, false},
+
+		//Nix generated flake.lock file
+		{"JSON/filenames/flake.lock", false, true},
+
+		//Bazel generated bzlmod lockfile
+		{"JSON/filenames/MODULE.bazel.lock", false, true},
+
+		//Deno generated deno.lock file
+		{"JSON/filenames/deno.lock", false, true},
+
+		//Generated Pascal _TLB file
+		{"Pascal/lazcomlib_1_0_tlb.pas", false, true},
+
+		//SQLx query files
+		{"Rust/.sqlx/query-2b8b1aae3740a05cb7179be9c7d5af30e8362c3cba0b07bc18fa32ff1a2232cc.json", false, true},
+
+		//IntelliJ IDEA project
+		{"Dummy/.idea/vcs.xml", false, true},
+
+		//Terraform lock
+		{"Dummy/.terraform.lock.hcl", false, true},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
This updates `GeneratedCodeNameMatchers` to match [current Linguist](https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/lib/linguist/generated.rb) and adds related tests from https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/test/test_generated.rb#L51-L231 and <https://github.com/github-linguist/linguist/blob/f164d13fa618023ecf2d8f2ed9a6ce5fae731346/test/test_blob.rb#L137-L264>.

Note that there have also been changes in Linguist to code that detects generated files based on content. This PR only updates matchers that rely on just the file name.