### PR TITLE
Add function to detect Ansible Vault

### DIFF
--- a/data/generated.go
+++ b/data/generated.go
@@ -172,6 +172,7 @@ var GeneratedCodeMatchers = []GeneratedCodeMatcher{
 	isGeneratedHaxe,
 	isGeneratedHTML,
 	isGeneratedJooq,
+	isAnsibleVault,
 }
 
 func canBeMinified(ext string) bool {
@@ -878,4 +879,9 @@ func countAppearancesInLine(line []byte, targets ...string) int {
 		count += bytes.Count(line, []byte(t))
 	}
 	return count
+}
+
+func isAnsibleVault(_, ext string, content []byte) bool {
+	firstLine := getFirstLine(content)
+	return bytes.HasPrefix(firstLine, []byte("$ANSIBLE_VAULT;"))
 }


### PR DESCRIPTION
Gitlab uses go-enry to detect which files should be collapsed by default in a Merge Request. This addition would add the capability to collapse and thus avoid polluting the Changes view with irrelevant ciphertext.

https://docs.gitlab.com/ee/user/project/merge_requests/changes.html#collapse-generated-files

File format: https://docs.ansible.com/ansible/2.9/user_guide/vault.html#vault-format