### PR TITLE
Fix search for lookbehind

### DIFF
--- a/internal/code-generator/generator/heuristics.go
+++ b/internal/code-generator/generator/heuristics.go
@@ -173,7 +173,7 @@ func parseYaml(file string) (*Heuristics, error) {
 func unsupportedRegexpSyntax(reg string) string {
 	var reasons []string
 
-	if strings.Contains(reg, `(?<`) {
+	if strings.Contains(reg, `(?<=`) || strings.Contains(reg, `(?<!`){
 		reasons = append(reasons, "lookbehind")
 	}
 	if strings.Contains(reg, `(?=`) || strings.Contains(reg, `(?!`) {


### PR DESCRIPTION
The previous search was matching the syntax `(?<name>re)` which is not a lookbehind. This new check is more reliable.

Sidenote:
The syntax `(?<name>re)` corresponds to a "named & numbered capturing group (submatch)". Looking at [RE2's syntax](https://github.com/google/re2/wiki/Syntax), this syntax doesn't have the mention "UNSUPPORTED", so one must assume that it is supported. However, we currently assume that the similar syntax `(?P<name>re)` is unsupported, but it also doesn't have the "UNSUPPORTED" mention 🤔.

I think what makes it confusing is that RE2 supports named capture group to make it easier to extract the value of the capture afterwards, but there can be no backreference to that group within the regex. Hence, a better approach to look for incompatible syntax would be to look for a backreference to a named capture group such as [`\k<name>`](https://ruby-doc.org/3.4.1/Regexp.html#class-Regexp-label-Subexpression+Calls:~:text=A%20named%20group%20may%20be%20backreferenced%20as%20%5Ck%3Cname%3E%3A) or  [`\g<name>`](https://ruby-doc.org/3.4.1/Regexp.html#class-Regexp-label-Subexpression+Calls) instead of looking for `(?P<name>re)` like we do at the moment.