### PR TITLE
Fix classification of unsupported languages

### DIFF
--- a/classifier.go
+++ b/classifier.go
@@ -47,10 +47,14 @@ func (c *naiveBayes) classify(content []byte, candidates map[string]float64) []s
 	var tokens []string
 	if !empty {
 		tokens = tokenizer.Tokenize(content)
+		empty = len(tokens) == 0
 	}
 
 	for language := range languages {
-		score := c.languagesLogProbabilities[language]
+		score, ok := c.languagesLogProbabilities[language]
+		if !ok {
+			continue
+		}
 		if !empty {
 			score += c.tokensLogProbability(tokens, language)
 		}

--- a/common_test.go
+++ b/common_test.go
@@ -438,6 +438,9 @@ func (s *enryTestSuite) TestGetLanguagesByClassifier() {
 		{name: "TestGetLanguagesByClassifier_5", filename: filepath.Join(s.samplesDir, "C/blob.c"), candidates: []string{"ruby"}, expected: "Ruby"},
 		{name: "TestGetLanguagesByClassifier_6", filename: filepath.Join(s.samplesDir, "Python/django-models-base.py"), candidates: []string{"python", "ruby", "c", "c++"}, expected: "Python"},
 		{name: "TestGetLanguagesByClassifier_7", filename: "", candidates: []string{"python"}, expected: "Python"},
+		// Check that unsupported "zero score" languages are neither returned nor outrank real languages.
+		{name: "TestGetLanguagesByClassifier_8", filename: filepath.Join(s.samplesDir, "C/blob.c"), candidates: []string{"FakeUnsupportedLanguage1", "FakeUnsupportedLanguage2"}, expected: OtherLanguage},
+		{name: "TestGetLanguagesByClassifier_9", filename: filepath.Join(s.samplesDir, "Checksums/single_hash_dec.crc32"), candidates: []string{"FakeUnsupportedLanguage", "Java", "Kotlin"}, expected: "Java"},
 	}
 
 	for _, test := range test {


### PR DESCRIPTION
If you call `enry.GetLanguageByClassifier` on short file contents with non-classifier-supported candidates languages in the list, the net result is go-enry returns one of these non-classifier-supported languages at random.

(This is because the `c.languagesLogProbabilities[language]` map access returns 0.0 for unlisted languages, which is a very high logprob.)

This fixes `GetLanguageByClassifier` to only consider languages actually supported by the classifier.