### PR TITLE
Add .gitattributes support for language detection overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,40 @@ macOS and linux platforms. Windows support is planned under [src-d/enry#150](htt
 Generated Rust bindings using a C static library are available at https://github.com/go-enry/rs-enry.
 
 
+## `.gitattributes` Support
+
+go-enry supports overriding language detection via `.gitattributes`, compatible with [Linguist's override system](https://github.com/github/linguist/blob/master/docs/overrides.md).
+
+### Supported attributes
+
+| Attribute | Example | Description |
+|-----------|---------|-------------|
+| `linguist-language` | `*.rb linguist-language=Ruby` | Override detected language |
+| `linguist-vendored` | `vendor/** linguist-vendored` | Mark/unmark as vendored |
+| `linguist-documentation` | `docs/** linguist-documentation` | Mark/unmark as documentation |
+| `linguist-generated` | `*.pb.go linguist-generated` | Mark/unmark as generated |
+| `linguist-detectable` | `*.sql linguist-detectable` | Force inclusion of data/prose languages |
+
+Use `-` prefix to unset: `-linguist-vendored`
+
+### API usage
+
+```go
+content, _ := os.ReadFile(".gitattributes")
+gitAttrs := enry.ParseGitAttributes(content)
+
+// Override checks (fall back to defaults when no rule matches)
+gitAttrs.IsVendor("vendor/lib.go")          // true
+gitAttrs.IsDocumentation("docs/guide.md")   // true
+gitAttrs.IsGenerated("api.pb.go", content)  // true
+
+// Language override
+lang, ok := gitAttrs.GetLanguage("Vagrantfile")
+// lang: "Ruby", ok: true
+```
+
+The `enry` CLI automatically reads `.gitattributes` from the root of the analyzed directory.
+
 ## Divergences from Linguist
 
 The `enry` library is based on the data from `github/linguist` version **v9.3.0**.
@@ -179,8 +213,6 @@ Parsing [linguist/samples](https://github.com/github/linguist/tree/master/sample
 - As of [Linguist v5.3.2](https://github.com/github/linguist/releases/tag/v5.3.2) it is using [flex-based scanner in C for tokenization](https://github.com/github/linguist/pull/3846). Enry still uses [extract_token](https://github.com/github/linguist/pull/3846/files#diff-d5179df0b71620e3fac4535cd1368d15L60) regex-based algorithm. See [#193](https://github.com/src-d/enry/issues/193).
 
 - Bayesian classifier can't distinguish "SQL" from "PLpgSQL. See [#194](https://github.com/src-d/enry/issues/194).
-
-- Overriding languages and types though `.gitattributes` is not yet supported. See [#18](https://github.com/src-d/enry/issues/18).
 
 - `enry` CLI output does NOT exclude `.gitignore`ed files and git submodules, as Linguist does
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,14 @@ Parsing [linguist/samples](https://github.com/github/linguist/tree/master/sample
 
 In all the cases above that have an issue number - we plan to update enry to match Linguist behavior.
 
+### `.gitattributes` pattern matching
+
+go-enry's `.gitattributes` glob matching covers all common patterns. The following features from Git's [wildmatch](https://github.com/git/git/blob/master/wildmatch.c) spec are not implemented:
+
+- **C-style quoted patterns**: patterns starting with `"` for paths containing spaces are not supported.
+- **Case-insensitive matching**: the `core.ignorecase` / `WM_CASEFOLD` mode is not implemented.
+- **Nested `.gitattributes` files**: only the root `.gitattributes` is read; subdirectory-level files are not loaded.
+
 > All the issues related to heuristics' regexp  syntax incompatibilities with the RE2 engine can be avoided by using `oniguruma` instead (see [instuctions](#misc))
 
 ## Benchmarks

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ gitAttrs.IsVendor("vendor/lib.go")          // true
 gitAttrs.IsDocumentation("docs/guide.md")   // true
 gitAttrs.IsGenerated("api.pb.go", content)  // true
 
+// Detectable override (tri-state: value, hasOverride)
+detectable, ok := gitAttrs.IsDetectable("schema.sql")
+// detectable: true, ok: true (explicitly marked detectable)
+
 // Language override
 lang, ok := gitAttrs.GetLanguage("Vagrantfile")
 // lang: "Ruby", ok: true

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ Use `-` prefix to unset: `-linguist-vendored`
 ### API usage
 
 ```go
-content, _ := os.ReadFile(".gitattributes")
-gitAttrs := enry.ParseGitAttributes(content)
+content, _ := ioutil.ReadFile(".gitattributes")
+gitAttrs, _ := enry.ParseGitAttributes(content)
 
 // Override checks (fall back to defaults when no rule matches)
 gitAttrs.IsVendor("vendor/lib.go")          // true

--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ go-enry supports overriding language detection via `.gitattributes`, compatible 
 
 Use `-` prefix to unset: `-linguist-vendored`
 
+Use `!` prefix to reset an attribute to the default behavior: `!linguist-vendored`
+
+Git-style attribute macros are also supported, for example:
+
+```text
+[attr]linguist-go linguist-language=Go
+*.myext linguist-go
+```
+
 ### API usage
 
 ```go
@@ -194,7 +203,6 @@ The `enry` CLI automatically reads `.gitattributes` from the root of the analyze
 
 **Known limitations:**
 - Only the root `.gitattributes` file is read. Git and Linguist support nested `.gitattributes` files in subdirectories; go-enry does not.
-- Backslash-escaped whitespace in patterns is not supported (patterns are split on whitespace).
 
 ## Divergences from Linguist
 

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ lang, ok := gitAttrs.GetLanguage("Vagrantfile")
 
 The `enry` CLI automatically reads `.gitattributes` from the root of the analyzed directory.
 
+**Known limitations:**
+- Only the root `.gitattributes` file is read. Git and Linguist support nested `.gitattributes` files in subdirectories; go-enry does not.
+- Backslash-escaped whitespace in patterns is not supported (patterns are split on whitespace).
+
 ## Divergences from Linguist
 
 The `enry` library is based on the data from `github/linguist` version **v9.3.0**.

--- a/cmd/enry/main.go
+++ b/cmd/enry/main.go
@@ -50,15 +50,26 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Determine the directory to use for .gitattributes lookup.
+	rootDir := root
+	if fileInfo.Mode().IsRegular() {
+		rootDir = filepath.Dir(root)
+	}
+
 	// Parse .gitattributes if present
 	var gitAttrs enry.GitAttributes
-	gaContent, err := ioutil.ReadFile(filepath.Join(root, ".gitattributes"))
+	gaContent, err := ioutil.ReadFile(filepath.Join(rootDir, ".gitattributes"))
 	if err == nil {
-		gitAttrs = enry.ParseGitAttributes(gaContent)
+		gitAttrs, err = enry.ParseGitAttributes(gaContent)
+		if err != nil {
+			log.Printf("warning: could not parse .gitattributes: %v", err)
+		}
+	} else if !os.IsNotExist(err) {
+		log.Printf("warning: could not read .gitattributes: %v", err)
 	}
 
 	if fileInfo.Mode().IsRegular() {
-		err = printFileAnalysis(root, limit, *jsonFlag)
+		err = printFileAnalysis(root, limit, *jsonFlag, gitAttrs)
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -272,7 +283,7 @@ func byteCountValues(root string, files []string) (float64, filelistError) {
 	return t, filesErr
 }
 
-func printFileAnalysis(file string, limit int64, isJSON bool) error {
+func printFileAnalysis(file string, limit int64, isJSON bool, gitAttrs enry.GitAttributes) error {
 	data, err := readFile(file, limit)
 	if err != nil {
 		return err
@@ -290,9 +301,12 @@ func printFileAnalysis(file string, limit int64, isJSON bool) error {
 
 	// functions below can work on a sample
 	fileType := getFileType(file, data)
-	language := enry.GetLanguage(file, data)
+	language, overridden := gitAttrs.GetLanguage(filepath.Base(file))
+	if !overridden {
+		language = enry.GetLanguage(file, data)
+	}
 	mimeType := enry.GetMIMEType(file, language)
-	vendored := enry.IsVendor(file)
+	vendored := gitAttrs.IsVendor(filepath.Base(file))
 
 	if isJSON {
 		return json.NewEncoder(os.Stdout).Encode(map[string]interface{}{

--- a/cmd/enry/main.go
+++ b/cmd/enry/main.go
@@ -76,8 +76,35 @@ func main() {
 		return
 	}
 
+	out, err := analyzeDir(root, limit, *allLangs, gitAttrs)
+
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	switch {
+	case *jsonFlag && !*breakdownFlag:
+		printJson(out, &buf)
+	case *jsonFlag && *breakdownFlag:
+		printBreakDown(out, &buf)
+	case *breakdownFlag:
+		printPercents(root, out, &buf, *countMode)
+		buf.WriteByte('\n')
+		printBreakDown(out, &buf)
+	default:
+		printPercents(root, out, &buf, *countMode)
+	}
+
+	fmt.Print(buf.String())
+}
+
+func analyzeDir(root string, limit int64, allLangs bool, gitAttrs enry.GitAttributes) (map[string][]string, error) {
 	out := make(map[string][]string, 0)
-	err = filepath.Walk(root, func(path string, f os.FileInfo, err error) error {
+	canPruneVendoredDirs := !gitAttrs.HasPotentialOverride("linguist-vendored")
+	canPruneDocumentationDirs := !gitAttrs.HasPotentialOverride("linguist-documentation")
+
+	err := filepath.Walk(root, func(path string, f os.FileInfo, err error) error {
 		if err != nil {
 			log.Println(err)
 			return filepath.SkipDir
@@ -93,25 +120,34 @@ func main() {
 			return nil
 		}
 
+		relativePath = filepath.ToSlash(relativePath)
 		if relativePath == "." {
 			return nil
 		}
 
-		if f.IsDir() {
-			relativePath = relativePath + "/"
+		isDir := f.IsDir()
+		if isDir {
+			relativePath += "/"
 		}
 
-		if gitAttrs.IsVendor(relativePath) || enry.IsDotFile(relativePath) ||
-			gitAttrs.IsDocumentation(relativePath) || enry.IsConfiguration(relativePath) {
-			// TODO(bzz): skip enry.IsGeneratedPath() after https://github.com/src-d/enry/issues/213
-			if f.IsDir() {
+		vendored := gitAttrs.IsVendor(relativePath)
+		documentation := gitAttrs.IsDocumentation(relativePath)
+		dotFile := enry.IsDotFile(relativePath)
+		configuration := enry.IsConfiguration(relativePath)
+
+		if isDir {
+			// Descendant -linguist-vendored / !linguist-vendored rules mean the
+			// parent cannot be pruned safely even if it is vendored itself.
+			if (vendored && canPruneVendoredDirs) ||
+				(documentation && canPruneDocumentationDirs) ||
+				dotFile || configuration {
 				return filepath.SkipDir
 			}
-
 			return nil
 		}
 
-		if f.IsDir() {
+		if vendored || documentation || dotFile || configuration {
+			// TODO(bzz): skip enry.IsGeneratedPath() after https://github.com/src-d/enry/issues/213
 			return nil
 		}
 
@@ -137,7 +173,7 @@ func main() {
 
 		// If we are not asked to display all, do as
 		// https://github.com/github/linguist/blob/bf95666fc15e49d556f2def4d0a85338423c25f3/lib/linguist/blob_helper.rb#L382
-		if !*allLangs {
+		if !allLangs {
 			detectable, hasOverride := gitAttrs.IsDetectable(relativePath)
 			if hasOverride {
 				if !detectable {
@@ -154,25 +190,7 @@ func main() {
 		return nil
 	})
 
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	var buf bytes.Buffer
-	switch {
-	case *jsonFlag && !*breakdownFlag:
-		printJson(out, &buf)
-	case *jsonFlag && *breakdownFlag:
-		printBreakDown(out, &buf)
-	case *breakdownFlag:
-		printPercents(root, out, &buf, *countMode)
-		buf.WriteByte('\n')
-		printBreakDown(out, &buf)
-	default:
-		printPercents(root, out, &buf, *countMode)
-	}
-
-	fmt.Print(buf.String())
+	return out, err
 }
 
 func usage() {
@@ -311,6 +329,7 @@ func printFileAnalysis(file string, rootDir string, limit int64, isJSON bool, gi
 	if relErr != nil {
 		relativePath = filepath.Base(file)
 	}
+	relativePath = filepath.ToSlash(relativePath)
 
 	// functions below can work on a sample
 	fileType := getFileType(file, data)

--- a/cmd/enry/main.go
+++ b/cmd/enry/main.go
@@ -50,6 +50,13 @@ func main() {
 		log.Fatal(err)
 	}
 
+	// Parse .gitattributes if present
+	var gitAttrs enry.GitAttributes
+	gaContent, err := ioutil.ReadFile(filepath.Join(root, ".gitattributes"))
+	if err == nil {
+		gitAttrs = enry.ParseGitAttributes(gaContent)
+	}
+
 	if fileInfo.Mode().IsRegular() {
 		err = printFileAnalysis(root, limit, *jsonFlag)
 		if err != nil {
@@ -83,8 +90,8 @@ func main() {
 			relativePath = relativePath + "/"
 		}
 
-		if enry.IsVendor(relativePath) || enry.IsDotFile(relativePath) ||
-			enry.IsDocumentation(relativePath) || enry.IsConfiguration(relativePath) {
+		if gitAttrs.IsVendor(relativePath) || enry.IsDotFile(relativePath) ||
+			gitAttrs.IsDocumentation(relativePath) || enry.IsConfiguration(relativePath) {
 			// TODO(bzz): skip enry.IsGeneratedPath() after https://github.com/src-d/enry/issues/213
 			if f.IsDir() {
 				return filepath.SkipDir
@@ -108,7 +115,11 @@ func main() {
 		}
 		// TODO(bzz): skip enry.IsGeneratedContent() as well, after https://github.com/src-d/enry/issues/213
 
-		language := enry.GetLanguage(filepath.Base(path), content)
+		// Check .gitattributes language override first
+		language, overridden := gitAttrs.GetLanguage(relativePath)
+		if !overridden {
+			language = enry.GetLanguage(filepath.Base(path), content)
+		}
 		if language == enry.OtherLanguage {
 			return nil
 		}

--- a/cmd/enry/main.go
+++ b/cmd/enry/main.go
@@ -69,7 +69,7 @@ func main() {
 	}
 
 	if fileInfo.Mode().IsRegular() {
-		err = printFileAnalysis(root, limit, *jsonFlag, gitAttrs)
+		err = printFileAnalysis(root, rootDir, limit, *jsonFlag, gitAttrs)
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -283,7 +283,7 @@ func byteCountValues(root string, files []string) (float64, filelistError) {
 	return t, filesErr
 }
 
-func printFileAnalysis(file string, limit int64, isJSON bool, gitAttrs enry.GitAttributes) error {
+func printFileAnalysis(file string, rootDir string, limit int64, isJSON bool, gitAttrs enry.GitAttributes) error {
 	data, err := readFile(file, limit)
 	if err != nil {
 		return err
@@ -299,14 +299,20 @@ func printFileAnalysis(file string, limit int64, isJSON bool, gitAttrs enry.GitA
 
 	totalLines, nonBlank := getLines(file, full)
 
+	// Compute relative path for .gitattributes matching
+	relativePath, relErr := filepath.Rel(rootDir, file)
+	if relErr != nil {
+		relativePath = filepath.Base(file)
+	}
+
 	// functions below can work on a sample
 	fileType := getFileType(file, data)
-	language, overridden := gitAttrs.GetLanguage(filepath.Base(file))
+	language, overridden := gitAttrs.GetLanguage(relativePath)
 	if !overridden {
 		language = enry.GetLanguage(file, data)
 	}
 	mimeType := enry.GetMIMEType(file, language)
-	vendored := gitAttrs.IsVendor(filepath.Base(file))
+	vendored := gitAttrs.IsVendor(relativePath)
 
 	if isJSON {
 		return json.NewEncoder(os.Stdout).Encode(map[string]interface{}{

--- a/cmd/enry/main.go
+++ b/cmd/enry/main.go
@@ -137,10 +137,17 @@ func main() {
 
 		// If we are not asked to display all, do as
 		// https://github.com/github/linguist/blob/bf95666fc15e49d556f2def4d0a85338423c25f3/lib/linguist/blob_helper.rb#L382
-		if !*allLangs &&
-			enry.GetLanguageType(language) != enry.Programming &&
-			enry.GetLanguageType(language) != enry.Markup {
-			return nil
+		if !*allLangs {
+			detectable, hasOverride := gitAttrs.IsDetectable(relativePath)
+			if hasOverride {
+				if !detectable {
+					return nil
+				}
+				// detectable=true: include regardless of language type
+			} else if enry.GetLanguageType(language) != enry.Programming &&
+				enry.GetLanguageType(language) != enry.Markup {
+				return nil
+			}
 		}
 
 		out[language] = append(out[language], relativePath)

--- a/cmd/enry/main_test.go
+++ b/cmd/enry/main_test.go
@@ -68,3 +68,29 @@ func TestAnalyzeDirRespectsNestedTrailingSlashVendorOverride(t *testing.T) {
 
 	assert.ElementsMatch(t, []string{"main.go", "vendor/github.com/pkg/errors/errors.go"}, out["Go"])
 }
+
+func TestAnalyzeDirRespectsMacroVendorOverride(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile := func(relativePath string, content string) {
+		path := filepath.Join(root, relativePath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+
+	writeFile(".gitattributes", "[attr]unvendor -linguist-vendored\nvendor/** linguist-vendored\nvendor/github.com/** unvendor\n")
+	writeFile("main.go", "package main\n")
+	writeFile("vendor/github.com/pkg/errors/errors.go", "package errors\n")
+	writeFile("vendor/acme/lib.go", "package acme\n")
+
+	content, err := os.ReadFile(filepath.Join(root, ".gitattributes"))
+	require.NoError(t, err)
+
+	gitAttrs, err := enry.ParseGitAttributes(content)
+	require.NoError(t, err)
+
+	out, err := analyzeDir(root, -1, true, gitAttrs)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"main.go", "vendor/github.com/pkg/errors/errors.go"}, out["Go"])
+}

--- a/cmd/enry/main_test.go
+++ b/cmd/enry/main_test.go
@@ -52,7 +52,7 @@ func TestAnalyzeDirRespectsNestedTrailingSlashVendorOverride(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
 	}
 
-	writeFile(".gitattributes", "vendor/** linguist-vendored\nvendor/github.com/ -linguist-vendored\n")
+	writeFile(".gitattributes", "vendor/** linguist-vendored\nvendor/github.com/** -linguist-vendored\n")
 	writeFile("main.go", "package main\n")
 	writeFile("vendor/github.com/pkg/errors/errors.go", "package errors\n")
 	writeFile("vendor/acme/lib.go", "package acme\n")

--- a/cmd/enry/main_test.go
+++ b/cmd/enry/main_test.go
@@ -1,7 +1,13 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
+
+	enry "github.com/go-enry/go-enry/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetLines(t *testing.T) {
@@ -35,4 +41,30 @@ func TestGetLines(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAnalyzeDirRespectsNestedTrailingSlashVendorOverride(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile := func(relativePath string, content string) {
+		path := filepath.Join(root, relativePath)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	}
+
+	writeFile(".gitattributes", "vendor/** linguist-vendored\nvendor/github.com/ -linguist-vendored\n")
+	writeFile("main.go", "package main\n")
+	writeFile("vendor/github.com/pkg/errors/errors.go", "package errors\n")
+	writeFile("vendor/acme/lib.go", "package acme\n")
+
+	content, err := os.ReadFile(filepath.Join(root, ".gitattributes"))
+	require.NoError(t, err)
+
+	gitAttrs, err := enry.ParseGitAttributes(content)
+	require.NoError(t, err)
+
+	out, err := analyzeDir(root, -1, true, gitAttrs)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"main.go", "vendor/github.com/pkg/errors/errors.go"}, out["Go"])
 }

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -374,8 +374,8 @@ func globMatch(pattern, str string) bool {
 			if len(str) == 0 || str[0] == '/' {
 				return false
 			}
-			// Find closing bracket
-			end := strings.Index(pattern, "]")
+			// Find closing bracket, skipping POSIX class [:..:]
+			end := findClosingBracket(pattern)
 			if end == -1 {
 				// No closing bracket, treat as literal
 				if str[0] != pattern[0] {
@@ -391,7 +391,10 @@ func globMatch(pattern, str string) bool {
 				negate = true
 				class = class[1:]
 			}
-			matched := matchCharClass(class, str[0])
+			matched, valid := matchCharClass(class, str[0])
+			if !valid {
+				return false
+			}
 			if negate {
 				matched = !matched
 			}
@@ -411,18 +414,106 @@ func globMatch(pattern, str string) bool {
 	return len(str) == 0
 }
 
-func matchCharClass(class string, ch byte) bool {
-	for i := 0; i < len(class); i++ {
-		if i+2 < len(class) && class[i+1] == '-' {
-			if ch >= class[i] && ch <= class[i+2] {
-				return true
+// findClosingBracket returns the index of the closing ']' in a bracket
+// expression starting at pattern[0] == '[', skipping POSIX classes [:name:].
+func findClosingBracket(pattern string) int {
+	for i := 1; i < len(pattern); i++ {
+		if pattern[i] == '[' && i+1 < len(pattern) && pattern[i+1] == ':' {
+			if end := strings.Index(pattern[i+2:], ":]"); end != -1 {
+				i += end + 3
+				continue
 			}
-			i += 2
-			continue
 		}
-		if class[i] == ch {
-			return true
+		if pattern[i] == ']' {
+			return i
 		}
 	}
-	return false
+	return -1
+}
+
+// matchCharClass returns (matched, valid). valid is false if the class
+// contains an unknown POSIX class name, in which case the caller should
+// treat the entire pattern as non-matching.
+func matchCharClass(class string, ch byte) (bool, bool) {
+	if !hasValidPOSIXClasses(class) {
+		return false, false
+	}
+	for len(class) > 0 {
+		if strings.HasPrefix(class, "[:") {
+			if end := strings.Index(class[2:], ":]"); end != -1 {
+				m, _ := matchPOSIXClass(class[2:2+end], ch)
+				if m {
+					return true, true
+				}
+				class = class[2+end+2:]
+				continue
+			}
+		}
+		if len(class) >= 3 && class[1] == '-' {
+			if ch >= class[0] && ch <= class[2] {
+				return true, true
+			}
+			class = class[3:]
+			continue
+		}
+		if class[0] == ch {
+			return true, true
+		}
+		class = class[1:]
+	}
+	return false, true
+}
+
+// hasValidPOSIXClasses checks that every [:name:] in the class string
+// refers to a known POSIX class.
+func hasValidPOSIXClasses(class string) bool {
+	for {
+		i := strings.Index(class, "[:")
+		if i == -1 {
+			return true
+		}
+		end := strings.Index(class[i+2:], ":]")
+		if end == -1 {
+			return true
+		}
+		if _, valid := matchPOSIXClass(class[i+2:i+2+end], 0); !valid {
+			return false
+		}
+		class = class[i+2+end+2:]
+	}
+}
+
+// matchPOSIXClass returns (matched, valid). valid is false for unknown class names.
+func matchPOSIXClass(name string, ch byte) (bool, bool) {
+	var m bool
+	switch name {
+	case "alnum":
+		m = (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+	case "alpha":
+		m = (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z')
+	case "blank":
+		m = ch == ' ' || ch == '\t'
+	case "cntrl":
+		m = ch < 0x20 || ch == 0x7f
+	case "digit":
+		m = ch >= '0' && ch <= '9'
+	case "graph":
+		m = ch >= 0x21 && ch <= 0x7e
+	case "lower":
+		m = ch >= 'a' && ch <= 'z'
+	case "print":
+		m = ch >= 0x20 && ch <= 0x7e
+	case "punct":
+		m = ch >= 0x21 && ch <= 0x7e &&
+			!((ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z'))
+	case "space":
+		m = ch == '\t' || ch == '\n' || ch == '\v' || ch == '\f' || ch == '\r' || ch == ' '
+	case "upper":
+		m = ch >= 'A' && ch <= 'Z'
+	case "xdigit":
+		m = (ch >= '0' && ch <= '9') || (ch >= 'A' && ch <= 'F') || (ch >= 'a' && ch <= 'f')
+	default:
+		return false, false
+	}
+	return m, true
 }

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -40,7 +40,10 @@ func ParseGitAttributes(content []byte) (GitAttributes, error) {
 		pattern := fields[0]
 		attrs := make(map[string]string)
 		for _, field := range fields[1:] {
-			if strings.HasPrefix(field, "-") {
+			if strings.HasPrefix(field, "!") {
+				// !attr means unspecified (reset to default)
+				attrs[field[1:]] = "unspecified"
+			} else if strings.HasPrefix(field, "-") {
 				// -attr means unset (false)
 				attrs[field[1:]] = "false"
 			} else if idx := strings.Index(field, "="); idx != -1 {
@@ -65,11 +68,16 @@ func ParseGitAttributes(content []byte) (GitAttributes, error) {
 // getAttr returns the value of a named attribute for the given path.
 // It returns the value from the last matching rule (git precedence: later rules win).
 // Iterates in reverse so we can return immediately on the first (i.e. last-defined) match.
+// If the attribute is "unspecified" (set via !attr), it is treated as not set,
+// causing the caller to fall back to default detection.
 func (ga GitAttributes) getAttr(path string, attr string) (string, bool) {
 	for i := len(ga.rules) - 1; i >= 0; i-- {
 		rule := ga.rules[i]
 		if matchGitPattern(rule.pattern, path) {
 			if val, ok := rule.attrs[attr]; ok {
+				if val == "unspecified" {
+					return "", false
+				}
 				return val, true
 			}
 		}
@@ -135,15 +143,22 @@ func (ga GitAttributes) GetLanguage(path string) (string, bool) {
 //   - "?" matches single char except "/"
 //   - Leading "/" anchors to the repo root; otherwise matches basename
 //     or anywhere if the pattern contains "/"
-//   - Trailing "/" only matches directory paths (i.e., paths ending with "/")
+//   - Trailing "/" matches the directory itself and all files inside it
 func matchGitPattern(pattern, path string) bool {
-	// Trailing slash means directory-only; match only when the path
-	// itself denotes a directory (represented as ending with "/").
+	// Trailing slash means directory pattern: matches the directory path
+	// (ending with "/") or any file inside the directory.
 	if strings.HasSuffix(pattern, "/") {
-		if !strings.HasSuffix(path, "/") {
+		dir := strings.TrimSuffix(pattern, "/")
+		if strings.HasSuffix(path, "/") {
+			// Directory path itself — match against dir name
+			path = strings.TrimSuffix(path, "/")
+			pattern = dir
+		} else if strings.HasPrefix(path, dir+"/") {
+			// File inside the directory — matches
+			return true
+		} else {
 			return false
 		}
-		pattern = strings.TrimSuffix(pattern, "/")
 	}
 
 	anchored := strings.HasPrefix(pattern, "/")
@@ -174,10 +189,12 @@ func globMatch(pattern, str string) bool {
 				if len(rest) == 0 {
 					return true
 				}
-				// Try matching rest against every suffix of str
+				// Try matching rest at path-component boundaries only
 				for i := 0; i <= len(str); i++ {
-					if globMatch(rest, str[i:]) {
-						return true
+					if i == 0 || str[i-1] == '/' {
+						if globMatch(rest, str[i:]) {
+							return true
+						}
 					}
 				}
 				return false

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -23,7 +23,7 @@ type gitAttributeRule struct {
 //   - "linguist-vendored" (set/true), "-linguist-vendored" (unset/false)
 //   - "linguist-language=Go"
 //   - etc.
-func ParseGitAttributes(content []byte) GitAttributes {
+func ParseGitAttributes(content []byte) (GitAttributes, error) {
 	var rules []gitAttributeRule
 	scanner := bufio.NewScanner(bytes.NewReader(content))
 	for scanner.Scan() {
@@ -55,23 +55,26 @@ func ParseGitAttributes(content []byte) GitAttributes {
 		rules = append(rules, gitAttributeRule{pattern: pattern, attrs: attrs})
 	}
 
-	return GitAttributes{rules: rules}
+	if err := scanner.Err(); err != nil {
+		return GitAttributes{}, err
+	}
+
+	return GitAttributes{rules: rules}, nil
 }
 
 // getAttr returns the value of a named attribute for the given path.
 // It returns the value from the last matching rule (git precedence: later rules win).
+// Iterates in reverse so we can return immediately on the first (i.e. last-defined) match.
 func (ga GitAttributes) getAttr(path string, attr string) (string, bool) {
-	var result string
-	var found bool
-	for _, rule := range ga.rules {
+	for i := len(ga.rules) - 1; i >= 0; i-- {
+		rule := ga.rules[i]
 		if matchGitPattern(rule.pattern, path) {
 			if val, ok := rule.attrs[attr]; ok {
-				result = val
-				found = true
+				return val, true
 			}
 		}
 	}
-	return result, found
+	return "", false
 }
 
 // IsVendor checks the linguist-vendored attribute for path.
@@ -132,12 +135,15 @@ func (ga GitAttributes) GetLanguage(path string) (string, bool) {
 //   - "?" matches single char except "/"
 //   - Leading "/" anchors to the repo root; otherwise matches basename
 //     or anywhere if the pattern contains "/"
-//   - Trailing "/" only matches directories (ignored for file matching)
+//   - Trailing "/" only matches directory paths (i.e., paths ending with "/")
 func matchGitPattern(pattern, path string) bool {
-	// Trailing slash means directory-only; for file matching we strip it
-	// and always fail since we're matching files
+	// Trailing slash means directory-only; match only when the path
+	// itself denotes a directory (represented as ending with "/").
 	if strings.HasSuffix(pattern, "/") {
-		return false
+		if !strings.HasSuffix(path, "/") {
+			return false
+		}
+		pattern = strings.TrimSuffix(pattern, "/")
 	}
 
 	anchored := strings.HasPrefix(pattern, "/")
@@ -195,7 +201,7 @@ func globMatch(pattern, str string) bool {
 			str = str[1:]
 		case '[':
 			// Character class matching
-			if len(str) == 0 {
+			if len(str) == 0 || str[0] == '/' {
 				return false
 			}
 			// Find closing bracket

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -75,6 +75,11 @@ func ParseGitAttributes(content []byte) (GitAttributes, error) {
 			continue
 		}
 
+		// Negative patterns are ignored in gitattributes (Git warns and skips).
+		if strings.HasPrefix(fields[0], "!") {
+			continue
+		}
+
 		if len(fields) < 2 {
 			continue
 		}
@@ -327,30 +332,46 @@ func matchGitPattern(pattern, path string) bool {
 	return globMatch(pattern, path)
 }
 
-// globMatch performs recursive glob matching with support for *, **, and ?.
+// globMatch performs recursive glob matching with support for *, **, ?, and \.
 func globMatch(pattern, str string) bool {
+	return globMatchInternal(pattern, str, 0)
+}
+
+// prev tracks the raw pattern byte immediately before the current pattern
+// position. It is 0 at the start of a pattern context. This is used for
+// the ** boundary check (Git wildmatch.c:95 "prev_p - pattern < 2").
+func globMatchInternal(pattern, str string, prev byte) bool {
 	for len(pattern) > 0 {
 		switch pattern[0] {
 		case '*':
 			if len(pattern) > 1 && pattern[1] == '*' {
-				// "**" matches everything including "/"
-				rest := pattern[2:]
-				// Consume optional trailing slash after **
-				if len(rest) > 0 && rest[0] == '/' {
-					rest = rest[1:]
-				}
-				if len(rest) == 0 {
-					return true
-				}
-				// Try matching rest at path-component boundaries only
-				for i := 0; i <= len(str); i++ {
-					if i == 0 || str[i-1] == '/' {
-						if globMatch(rest, str[i:]) {
-							return true
+				// Check if ** is at a path boundary:
+				// preceded by start-of-pattern or '/'
+				// AND followed by end-of-pattern, '/', or '\/'
+				atBoundary := (prev == 0 || prev == '/') &&
+					(len(pattern) == 2 || pattern[2] == '/' ||
+						(len(pattern) > 3 && pattern[2] == '\\' && pattern[3] == '/'))
+				if atBoundary {
+					rest := pattern[2:]
+					restPrev := byte('*')
+					if len(rest) > 0 && rest[0] == '/' {
+						restPrev = '/'
+						rest = rest[1:]
+					}
+					if len(rest) == 0 {
+						return true
+					}
+					for i := 0; i <= len(str); i++ {
+						if i == 0 || str[i-1] == '/' {
+							if globMatchInternal(rest, str[i:], restPrev) {
+								return true
+							}
 						}
 					}
+					return false
 				}
-				return false
+				// ** not at boundary: skip extra * and treat as single *
+				pattern = pattern[1:]
 			}
 			// "*" matches anything except "/"
 			rest := pattern[1:]
@@ -358,7 +379,7 @@ func globMatch(pattern, str string) bool {
 				if i > 0 && str[i-1] == '/' {
 					break
 				}
-				if globMatch(rest, str[i:]) {
+				if globMatchInternal(rest, str[i:], '*') {
 					return true
 				}
 			}
@@ -367,6 +388,7 @@ func globMatch(pattern, str string) bool {
 			if len(str) == 0 || str[0] == '/' {
 				return false
 			}
+			prev = '?'
 			pattern = pattern[1:]
 			str = str[1:]
 		case '[':
@@ -381,6 +403,7 @@ func globMatch(pattern, str string) bool {
 				if str[0] != pattern[0] {
 					return false
 				}
+				prev = pattern[0]
 				pattern = pattern[1:]
 				str = str[1:]
 				continue
@@ -401,12 +424,25 @@ func globMatch(pattern, str string) bool {
 			if !matched {
 				return false
 			}
+			prev = ']'
 			pattern = pattern[end+1:]
+			str = str[1:]
+		case '\\':
+			pattern = pattern[1:]
+			if len(pattern) == 0 {
+				return false
+			}
+			if len(str) == 0 || pattern[0] != str[0] {
+				return false
+			}
+			prev = pattern[0]
+			pattern = pattern[1:]
 			str = str[1:]
 		default:
 			if len(str) == 0 || pattern[0] != str[0] {
 				return false
 			}
+			prev = pattern[0]
 			pattern = pattern[1:]
 			str = str[1:]
 		}
@@ -416,24 +452,41 @@ func globMatch(pattern, str string) bool {
 
 // findClosingBracket returns the index of the closing ']' in a bracket
 // expression starting at pattern[0] == '[', skipping POSIX classes [:name:].
+// Per POSIX/Git wildmatch: ']' immediately after '[' (or '[!' / '[^') is a
+// literal class member, not the closing bracket. Backslash escapes are also
+// handled: '\]' inside a bracket is a literal ']'.
 func findClosingBracket(pattern string) int {
-	for i := 1; i < len(pattern); i++ {
+	i := 1
+	if i < len(pattern) && (pattern[i] == '!' || pattern[i] == '^') {
+		i++
+	}
+	// ] immediately after [ (or [!/[^) is a literal class member
+	if i < len(pattern) && pattern[i] == ']' {
+		i++
+	}
+	for i < len(pattern) {
+		if pattern[i] == '\\' && i+1 < len(pattern) {
+			i += 2 // skip escaped character
+			continue
+		}
 		if pattern[i] == '[' && i+1 < len(pattern) && pattern[i+1] == ':' {
 			if end := strings.Index(pattern[i+2:], ":]"); end != -1 {
-				i += end + 3
+				i += end + 4
 				continue
 			}
 		}
 		if pattern[i] == ']' {
 			return i
 		}
+		i++
 	}
 	return -1
 }
 
 // matchCharClass returns (matched, valid). valid is false if the class
 // contains an unknown POSIX class name, in which case the caller should
-// treat the entire pattern as non-matching.
+// treat the entire pattern as non-matching. Backslash escapes are handled:
+// '\x' inside a class is treated as literal 'x'.
 func matchCharClass(class string, ch byte) (bool, bool) {
 	if !hasValidPOSIXClasses(class) {
 		return false, false
@@ -449,17 +502,32 @@ func matchCharClass(class string, ch byte) (bool, bool) {
 				continue
 			}
 		}
-		if len(class) >= 3 && class[1] == '-' {
-			if ch >= class[0] && ch <= class[2] {
+		// Get current character, handling escape
+		cur := class[0]
+		advance := 1
+		if cur == '\\' && len(class) > 1 {
+			cur = class[1]
+			advance = 2
+		}
+		// Check for range: cur-high
+		rest := class[advance:]
+		if len(rest) >= 2 && rest[0] == '-' && rest[1] != ']' {
+			high := rest[1]
+			highAdv := 2
+			if high == '\\' && len(rest) > 2 {
+				high = rest[2]
+				highAdv = 3
+			}
+			if ch >= cur && ch <= high {
 				return true, true
 			}
-			class = class[3:]
+			class = rest[highAdv:]
 			continue
 		}
-		if class[0] == ch {
+		if cur == ch {
 			return true, true
 		}
-		class = class[1:]
+		class = rest
 	}
 	return false, true
 }

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -113,13 +113,20 @@ func (ga GitAttributes) IsGenerated(path string, content []byte) bool {
 }
 
 // IsDetectable checks the linguist-detectable attribute for path.
-// Returns true only if explicitly set. By default files of type data or prose
-// are not detectable.
-func (ga GitAttributes) IsDetectable(path string) bool {
+// Returns (value, hasOverride). When hasOverride is true, value indicates
+// whether the file should be included in language statistics regardless of
+// its language type. When hasOverride is false, the caller should fall back
+// to default behavior (include programming/markup, exclude data/prose).
+//
+// Per Linguist semantics:
+//   - "linguist-detectable" forces inclusion (e.g., data/prose languages in stats)
+//   - "-linguist-detectable" forces exclusion (e.g., hide a programming language)
+//   - No rule means use default language-type-based detection
+func (ga GitAttributes) IsDetectable(path string) (bool, bool) {
 	if val, ok := ga.getAttr(path, "linguist-detectable"); ok {
-		return val != "false"
+		return val != "false", true
 	}
-	return false
+	return false, false
 }
 
 // GetLanguage checks the linguist-language attribute for path.

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -301,20 +301,17 @@ func (ga GitAttributes) HasPotentialOverride(attr string) bool {
 //     or anywhere if the pattern contains "/"
 //   - Trailing "/" matches the directory itself and all files inside it
 func matchGitPattern(pattern, path string) bool {
-	// Trailing slash means directory pattern: matches the directory path
-	// (ending with "/") or any file inside the directory.
+	// Trailing slash means directory-only pattern. Unlike .gitignore,
+	// .gitattributes does NOT recurse into directories — the pattern only
+	// matches paths that are themselves directories (ending with "/").
+	// The Git docs call trailing "/" in .gitattributes "pointless";
+	// users should use "vendor/**" instead of "vendor/".
 	if strings.HasSuffix(pattern, "/") {
-		dir := strings.TrimSuffix(pattern, "/")
-		if strings.HasSuffix(path, "/") {
-			// Directory path itself — match against dir name
-			path = strings.TrimSuffix(path, "/")
-			pattern = dir
-		} else if strings.HasPrefix(path, dir+"/") {
-			// File inside the directory — matches
-			return true
-		} else {
+		if !strings.HasSuffix(path, "/") {
 			return false
 		}
+		pattern = strings.TrimSuffix(pattern, "/")
+		path = strings.TrimSuffix(path, "/")
 	}
 
 	anchored := strings.HasPrefix(pattern, "/")

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -143,6 +143,19 @@ func (ga GitAttributes) GetLanguage(path string) (string, bool) {
 	return "", false
 }
 
+// HasPotentialOverride reports whether attr is ever explicitly unset or reset
+// in .gitattributes. Directory-level pruning in callers must be conservative
+// when such rules exist, because a later descendant rule may need to override
+// the parent directory classification.
+func (ga GitAttributes) HasPotentialOverride(attr string) bool {
+	for _, rule := range ga.rules {
+		if val, ok := rule.attrs[attr]; ok && (val == "false" || val == "unspecified") {
+			return true
+		}
+	}
+	return false
+}
+
 // matchGitPattern implements git-style glob matching compatible with
 // linguist's fnmatch(FNM_PATHNAME):
 //   - "*" matches anything except "/"

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -14,17 +14,46 @@ type GitAttributes struct {
 
 type gitAttributeRule struct {
 	pattern string
-	attrs   map[string]string
+	attrs   map[string]gitAttributeValue
+}
+
+type gitAttributeValueKind uint8
+
+const (
+	gitAttributeValueSet gitAttributeValueKind = iota
+	gitAttributeValueUnset
+	gitAttributeValueUnspecified
+	gitAttributeValueString
+)
+
+type gitAttributeValue struct {
+	kind  gitAttributeValueKind
+	value string
+}
+
+type gitAttributeAssignment struct {
+	name        string
+	value       gitAttributeValue
+	expandMacro bool
+}
+
+type gitAttributeRawRule struct {
+	pattern     string
+	assignments []gitAttributeAssignment
 }
 
 // ParseGitAttributes parses the content of a .gitattributes file.
-// Each non-comment, non-empty line has the form: pattern attr1 attr2=value ...
-// Attributes can be:
-//   - "linguist-vendored" (set/true), "-linguist-vendored" (unset/false)
-//   - "linguist-language=Go"
-//   - etc.
+// Each non-comment, non-empty line has the form:
+//   - pattern attr1 attr2=value ...
+//   - [attr]macroName attr1 attr2=value ...
+//
+// Attributes can be bare (set), prefixed with "-" (unset), prefixed with "!"
+// (reset to unspecified), or assigned via "=" (string value).
+// Bare macro references are expanded recursively after parsing, matching Git's
+// behavior even when the macro is defined later in the file.
 func ParseGitAttributes(content []byte) (GitAttributes, error) {
-	var rules []gitAttributeRule
+	var rawRules []gitAttributeRawRule
+	macros := make(map[string][]gitAttributeAssignment)
 	scanner := bufio.NewScanner(bytes.NewReader(content))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
@@ -33,63 +62,170 @@ func ParseGitAttributes(content []byte) (GitAttributes, error) {
 		}
 
 		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+
+		if strings.HasPrefix(fields[0], "[attr]") {
+			name := strings.TrimPrefix(fields[0], "[attr]")
+			if name == "" {
+				continue
+			}
+			macros[name] = parseGitAttributeAssignments(fields[1:])
+			continue
+		}
+
 		if len(fields) < 2 {
 			continue
 		}
 
-		pattern := fields[0]
-		attrs := make(map[string]string)
-		for _, field := range fields[1:] {
-			if strings.HasPrefix(field, "!") {
-				// !attr means unspecified (reset to default)
-				attrs[field[1:]] = "unspecified"
-			} else if strings.HasPrefix(field, "-") {
-				// -attr means unset (false)
-				attrs[field[1:]] = "false"
-			} else if idx := strings.Index(field, "="); idx != -1 {
-				// attr=value
-				attrs[field[:idx]] = field[idx+1:]
-			} else {
-				// attr alone means set (true)
-				attrs[field] = "true"
-			}
-		}
-
-		rules = append(rules, gitAttributeRule{pattern: pattern, attrs: attrs})
+		rawRules = append(rawRules, gitAttributeRawRule{
+			pattern:     fields[0],
+			assignments: parseGitAttributeAssignments(fields[1:]),
+		})
 	}
 
 	if err := scanner.Err(); err != nil {
 		return GitAttributes{}, err
 	}
 
+	rules := make([]gitAttributeRule, 0, len(rawRules))
+	memo := make(map[string]map[string]gitAttributeValue)
+	for _, rule := range rawRules {
+		rules = append(rules, gitAttributeRule{
+			pattern: rule.pattern,
+			attrs:   resolveGitAttributeAssignments(rule.assignments, macros, memo, map[string]bool{}),
+		})
+	}
+
 	return GitAttributes{rules: rules}, nil
+}
+
+func parseGitAttributeAssignments(fields []string) []gitAttributeAssignment {
+	assignments := make([]gitAttributeAssignment, 0, len(fields))
+	for _, field := range fields {
+		switch {
+		case strings.HasPrefix(field, "!"):
+			assignments = append(assignments, gitAttributeAssignment{
+				name:  field[1:],
+				value: gitAttributeValue{kind: gitAttributeValueUnspecified},
+			})
+		case strings.HasPrefix(field, "-"):
+			assignments = append(assignments, gitAttributeAssignment{
+				name:  field[1:],
+				value: gitAttributeValue{kind: gitAttributeValueUnset},
+			})
+		case strings.Contains(field, "="):
+			idx := strings.Index(field, "=")
+			assignments = append(assignments, gitAttributeAssignment{
+				name:  field[:idx],
+				value: gitAttributeValue{kind: gitAttributeValueString, value: field[idx+1:]},
+			})
+		default:
+			assignments = append(assignments, gitAttributeAssignment{
+				name:        field,
+				value:       gitAttributeValue{kind: gitAttributeValueSet},
+				expandMacro: true,
+			})
+		}
+	}
+	return assignments
+}
+
+func resolveGitAttributeAssignments(assignments []gitAttributeAssignment, macros map[string][]gitAttributeAssignment, memo map[string]map[string]gitAttributeValue, visiting map[string]bool) map[string]gitAttributeValue {
+	resolved := make(map[string]gitAttributeValue)
+	for _, assignment := range assignments {
+		if assignment.expandMacro {
+			if expanded, ok := resolveGitAttributeMacro(assignment.name, macros, memo, visiting); ok {
+				for name, value := range expanded {
+					resolved[name] = value
+				}
+				continue
+			}
+		}
+		resolved[assignment.name] = assignment.value
+	}
+	return resolved
+}
+
+func resolveGitAttributeMacro(name string, macros map[string][]gitAttributeAssignment, memo map[string]map[string]gitAttributeValue, visiting map[string]bool) (map[string]gitAttributeValue, bool) {
+	if expanded, ok := memo[name]; ok {
+		return cloneGitAttributeValues(expanded), true
+	}
+
+	assignments, ok := macros[name]
+	if !ok {
+		return nil, false
+	}
+
+	if visiting[name] {
+		return map[string]gitAttributeValue{}, true
+	}
+
+	visiting[name] = true
+	expanded := resolveGitAttributeAssignments(assignments, macros, memo, visiting)
+	delete(visiting, name)
+
+	memo[name] = cloneGitAttributeValues(expanded)
+	return expanded, true
+}
+
+func cloneGitAttributeValues(attrs map[string]gitAttributeValue) map[string]gitAttributeValue {
+	cloned := make(map[string]gitAttributeValue, len(attrs))
+	for name, value := range attrs {
+		cloned[name] = value
+	}
+	return cloned
+}
+
+func (v gitAttributeValue) boolValue() bool {
+	switch v.kind {
+	case gitAttributeValueUnset:
+		return false
+	case gitAttributeValueString:
+		return v.value != "false"
+	default:
+		return true
+	}
+}
+
+func (v gitAttributeValue) textValue() string {
+	switch v.kind {
+	case gitAttributeValueSet:
+		return "true"
+	case gitAttributeValueUnset:
+		return "false"
+	default:
+		return v.value
+	}
 }
 
 // getAttr returns the value of a named attribute for the given path.
 // It returns the value from the last matching rule (git precedence: later rules win).
 // Iterates in reverse so we can return immediately on the first (i.e. last-defined) match.
-// If the attribute is "unspecified" (set via !attr), it is treated as not set,
-// causing the caller to fall back to default detection.
-func (ga GitAttributes) getAttr(path string, attr string) (string, bool) {
+// If the attribute is unspecified (set via !attr or via a macro that resolves to
+// !attr), it is treated as not set, causing the caller to fall back to default
+// detection.
+func (ga GitAttributes) getAttr(path string, attr string) (gitAttributeValue, bool) {
 	for i := len(ga.rules) - 1; i >= 0; i-- {
 		rule := ga.rules[i]
 		if matchGitPattern(rule.pattern, path) {
 			if val, ok := rule.attrs[attr]; ok {
-				if val == "unspecified" {
-					return "", false
+				if val.kind == gitAttributeValueUnspecified {
+					return gitAttributeValue{}, false
 				}
 				return val, true
 			}
 		}
 	}
-	return "", false
+	return gitAttributeValue{}, false
 }
 
 // IsVendor checks the linguist-vendored attribute for path.
 // If no rule matches, it falls back to the default IsVendor detection.
 func (ga GitAttributes) IsVendor(path string) bool {
 	if val, ok := ga.getAttr(path, "linguist-vendored"); ok {
-		return val != "false"
+		return val.boolValue()
 	}
 	return IsVendor(path)
 }
@@ -98,7 +234,7 @@ func (ga GitAttributes) IsVendor(path string) bool {
 // If no rule matches, it falls back to the default IsDocumentation detection.
 func (ga GitAttributes) IsDocumentation(path string) bool {
 	if val, ok := ga.getAttr(path, "linguist-documentation"); ok {
-		return val != "false"
+		return val.boolValue()
 	}
 	return IsDocumentation(path)
 }
@@ -107,7 +243,7 @@ func (ga GitAttributes) IsDocumentation(path string) bool {
 // If no rule matches, it falls back to the default IsGenerated detection.
 func (ga GitAttributes) IsGenerated(path string, content []byte) bool {
 	if val, ok := ga.getAttr(path, "linguist-generated"); ok {
-		return val != "false"
+		return val.boolValue()
 	}
 	return IsGenerated(path, content)
 }
@@ -124,7 +260,7 @@ func (ga GitAttributes) IsGenerated(path string, content []byte) bool {
 //   - No rule means use default language-type-based detection
 func (ga GitAttributes) IsDetectable(path string) (bool, bool) {
 	if val, ok := ga.getAttr(path, "linguist-detectable"); ok {
-		return val != "false", true
+		return val.boolValue(), true
 	}
 	return false, false
 }
@@ -134,11 +270,11 @@ func (ga GitAttributes) IsDetectable(path string) (bool, bool) {
 // Returns the language and true if an override was found.
 func (ga GitAttributes) GetLanguage(path string) (string, bool) {
 	if val, ok := ga.getAttr(path, "linguist-language"); ok {
-		if lang, ok := GetLanguageByAlias(val); ok {
+		if lang, ok := GetLanguageByAlias(val.textValue()); ok {
 			return lang, true
 		}
 		// Return as-is if alias resolution fails (could be a valid language name)
-		return val, true
+		return val.textValue(), true
 	}
 	return "", false
 }
@@ -149,7 +285,7 @@ func (ga GitAttributes) GetLanguage(path string) (string, bool) {
 // the parent directory classification.
 func (ga GitAttributes) HasPotentialOverride(attr string) bool {
 	for _, rule := range ga.rules {
-		if val, ok := rule.attrs[attr]; ok && (val == "false" || val == "unspecified") {
+		if val, ok := rule.attrs[attr]; ok && (val.kind == gitAttributeValueUnset || val.kind == gitAttributeValueUnspecified) {
 			return true
 		}
 	}

--- a/gitattributes.go
+++ b/gitattributes.go
@@ -1,0 +1,252 @@
+package enry
+
+import (
+	"bufio"
+	"bytes"
+	"path/filepath"
+	"strings"
+)
+
+// GitAttributes holds parsed .gitattributes rules for overriding language detection.
+type GitAttributes struct {
+	rules []gitAttributeRule
+}
+
+type gitAttributeRule struct {
+	pattern string
+	attrs   map[string]string
+}
+
+// ParseGitAttributes parses the content of a .gitattributes file.
+// Each non-comment, non-empty line has the form: pattern attr1 attr2=value ...
+// Attributes can be:
+//   - "linguist-vendored" (set/true), "-linguist-vendored" (unset/false)
+//   - "linguist-language=Go"
+//   - etc.
+func ParseGitAttributes(content []byte) GitAttributes {
+	var rules []gitAttributeRule
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+
+		pattern := fields[0]
+		attrs := make(map[string]string)
+		for _, field := range fields[1:] {
+			if strings.HasPrefix(field, "-") {
+				// -attr means unset (false)
+				attrs[field[1:]] = "false"
+			} else if idx := strings.Index(field, "="); idx != -1 {
+				// attr=value
+				attrs[field[:idx]] = field[idx+1:]
+			} else {
+				// attr alone means set (true)
+				attrs[field] = "true"
+			}
+		}
+
+		rules = append(rules, gitAttributeRule{pattern: pattern, attrs: attrs})
+	}
+
+	return GitAttributes{rules: rules}
+}
+
+// getAttr returns the value of a named attribute for the given path.
+// It returns the value from the last matching rule (git precedence: later rules win).
+func (ga GitAttributes) getAttr(path string, attr string) (string, bool) {
+	var result string
+	var found bool
+	for _, rule := range ga.rules {
+		if matchGitPattern(rule.pattern, path) {
+			if val, ok := rule.attrs[attr]; ok {
+				result = val
+				found = true
+			}
+		}
+	}
+	return result, found
+}
+
+// IsVendor checks the linguist-vendored attribute for path.
+// If no rule matches, it falls back to the default IsVendor detection.
+func (ga GitAttributes) IsVendor(path string) bool {
+	if val, ok := ga.getAttr(path, "linguist-vendored"); ok {
+		return val != "false"
+	}
+	return IsVendor(path)
+}
+
+// IsDocumentation checks the linguist-documentation attribute for path.
+// If no rule matches, it falls back to the default IsDocumentation detection.
+func (ga GitAttributes) IsDocumentation(path string) bool {
+	if val, ok := ga.getAttr(path, "linguist-documentation"); ok {
+		return val != "false"
+	}
+	return IsDocumentation(path)
+}
+
+// IsGenerated checks the linguist-generated attribute for path.
+// If no rule matches, it falls back to the default IsGenerated detection.
+func (ga GitAttributes) IsGenerated(path string, content []byte) bool {
+	if val, ok := ga.getAttr(path, "linguist-generated"); ok {
+		return val != "false"
+	}
+	return IsGenerated(path, content)
+}
+
+// IsDetectable checks the linguist-detectable attribute for path.
+// Returns true only if explicitly set. By default files of type data or prose
+// are not detectable.
+func (ga GitAttributes) IsDetectable(path string) bool {
+	if val, ok := ga.getAttr(path, "linguist-detectable"); ok {
+		return val != "false"
+	}
+	return false
+}
+
+// GetLanguage checks the linguist-language attribute for path.
+// If set, the language name is resolved via GetLanguageByAlias for canonical naming.
+// Returns the language and true if an override was found.
+func (ga GitAttributes) GetLanguage(path string) (string, bool) {
+	if val, ok := ga.getAttr(path, "linguist-language"); ok {
+		if lang, ok := GetLanguageByAlias(val); ok {
+			return lang, true
+		}
+		// Return as-is if alias resolution fails (could be a valid language name)
+		return val, true
+	}
+	return "", false
+}
+
+// matchGitPattern implements git-style glob matching compatible with
+// linguist's fnmatch(FNM_PATHNAME):
+//   - "*" matches anything except "/"
+//   - "**" matches everything including "/"
+//   - "?" matches single char except "/"
+//   - Leading "/" anchors to the repo root; otherwise matches basename
+//     or anywhere if the pattern contains "/"
+//   - Trailing "/" only matches directories (ignored for file matching)
+func matchGitPattern(pattern, path string) bool {
+	// Trailing slash means directory-only; for file matching we strip it
+	// and always fail since we're matching files
+	if strings.HasSuffix(pattern, "/") {
+		return false
+	}
+
+	anchored := strings.HasPrefix(pattern, "/")
+	if anchored {
+		pattern = pattern[1:]
+	}
+
+	// If pattern contains no slash (and wasn't anchored), match against basename
+	if !anchored && !strings.Contains(pattern, "/") {
+		path = filepath.Base(path)
+	}
+
+	return globMatch(pattern, path)
+}
+
+// globMatch performs recursive glob matching with support for *, **, and ?.
+func globMatch(pattern, str string) bool {
+	for len(pattern) > 0 {
+		switch pattern[0] {
+		case '*':
+			if len(pattern) > 1 && pattern[1] == '*' {
+				// "**" matches everything including "/"
+				rest := pattern[2:]
+				// Consume optional trailing slash after **
+				if len(rest) > 0 && rest[0] == '/' {
+					rest = rest[1:]
+				}
+				if len(rest) == 0 {
+					return true
+				}
+				// Try matching rest against every suffix of str
+				for i := 0; i <= len(str); i++ {
+					if globMatch(rest, str[i:]) {
+						return true
+					}
+				}
+				return false
+			}
+			// "*" matches anything except "/"
+			rest := pattern[1:]
+			for i := 0; i <= len(str); i++ {
+				if i > 0 && str[i-1] == '/' {
+					break
+				}
+				if globMatch(rest, str[i:]) {
+					return true
+				}
+			}
+			return false
+		case '?':
+			if len(str) == 0 || str[0] == '/' {
+				return false
+			}
+			pattern = pattern[1:]
+			str = str[1:]
+		case '[':
+			// Character class matching
+			if len(str) == 0 {
+				return false
+			}
+			// Find closing bracket
+			end := strings.Index(pattern, "]")
+			if end == -1 {
+				// No closing bracket, treat as literal
+				if str[0] != pattern[0] {
+					return false
+				}
+				pattern = pattern[1:]
+				str = str[1:]
+				continue
+			}
+			class := pattern[1:end]
+			negate := false
+			if len(class) > 0 && (class[0] == '!' || class[0] == '^') {
+				negate = true
+				class = class[1:]
+			}
+			matched := matchCharClass(class, str[0])
+			if negate {
+				matched = !matched
+			}
+			if !matched {
+				return false
+			}
+			pattern = pattern[end+1:]
+			str = str[1:]
+		default:
+			if len(str) == 0 || pattern[0] != str[0] {
+				return false
+			}
+			pattern = pattern[1:]
+			str = str[1:]
+		}
+	}
+	return len(str) == 0
+}
+
+func matchCharClass(class string, ch byte) bool {
+	for i := 0; i < len(class); i++ {
+		if i+2 < len(class) && class[i+1] == '-' {
+			if ch >= class[i] && ch <= class[i+2] {
+				return true
+			}
+			i += 2
+			continue
+		}
+		if class[i] == ch {
+			return true
+		}
+	}
+	return false
+}

--- a/gitattributes_edge_test.go
+++ b/gitattributes_edge_test.go
@@ -1,0 +1,742 @@
+package enry
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// EC-1: matchGitPattern — path-component boundary for **
+// ---------------------------------------------------------------------------
+
+// TestEdgeDoubleStarPathBoundary verifies that ** only matches at path
+// component boundaries, not in the middle of a filename.
+func TestEdgeDoubleStarPathBoundary(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+		note    string
+	}{
+		// ** should NOT match inside a filename component
+		{"**/foo.go", "barfoo.go", false, "** must not mid-component match: barfoo.go contains 'foo.go' at offset 3"},
+		{"**/foo.go", "xfoo.go", false, "** must not mid-component match: xfoo.go"},
+		{"**/test", "atest", false, "** must not match 'atest' for pattern **/test"},
+		{"**/vendor/**", "bvendor/lib.go", false, "** must not match 'bvendor' as 'vendor'"},
+		{"**/vendor/**", "notvendor/x.go", false, "** must not match 'notvendor' prefix"},
+
+		// ** SHOULD match at component boundaries
+		{"**/foo.go", "foo.go", true, "** matches at root"},
+		{"**/foo.go", "src/foo.go", true, "** matches one level deep"},
+		{"**/foo.go", "src/lib/foo.go", true, "** matches two levels deep"},
+		{"**/vendor/**", "vendor/foo.go", true, "** matches vendor at root"},
+		{"**/vendor/**", "a/vendor/foo.go", true, "** matches vendor one level deep"},
+		{"**/vendor/**", "a/b/vendor/foo.go", true, "** matches vendor two levels deep"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "%s: matchGitPattern(%q, %q)", tt.note, tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-2: Trailing-slash patterns — directory contents
+// ---------------------------------------------------------------------------
+
+// TestEdgeTrailingSlashDirectory verifies that a trailing-slash pattern
+// (e.g. "vendor/") matches files INSIDE that directory, not just the literal
+// path ending in "/".
+func TestEdgeTrailingSlashDirectory(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+		note    string
+	}{
+		// Files inside vendor/ should match vendor/ pattern
+		{"vendor/", "vendor/foo.go", true, "files in vendor/ should be matched"},
+		{"vendor/", "vendor/lib/bar.go", true, "nested files in vendor/ should be matched"},
+		{"vendor/", "vendor/", true, "the directory itself should match"},
+
+		// Files outside should not match
+		{"vendor/", "src/vendor/foo.go", false, "files in src/vendor/ should not match anchored vendor/"},
+		{"vendor/", "notvendor/foo.go", false, "files in notvendor/ should not match vendor/"},
+		{"vendor/", "vendor", false, "bare 'vendor' without trailing slash should not match"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "%s: matchGitPattern(%q, %q)", tt.note, tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-3: Double-star in middle of pattern
+// ---------------------------------------------------------------------------
+
+func TestEdgeDoubleStarMiddle(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"src/**/test.go", "src/test.go", true},          // zero dirs
+		{"src/**/test.go", "src/a/test.go", true},         // one dir
+		{"src/**/test.go", "src/a/b/test.go", true},       // two dirs
+		{"src/**/test.go", "src/a/b/c/test.go", true},     // three dirs
+		{"src/**/test.go", "test.go", false},              // missing src prefix
+		{"src/**/test.go", "other/a/test.go", false},      // wrong top dir
+		{"src/**/*.go", "src/foo.go", true},               // zero dirs
+		{"src/**/*.go", "src/pkg/foo.go", true},           // one dir
+		{"src/**/*.go", "src/pkg/sub/foo.go", true},       // nested
+		{"src/**/*.go", "pkg/foo.go", false},              // missing src
+		{"a/**/b/**/c.go", "a/b/c.go", true},              // two double-stars, both match zero
+		{"a/**/b/**/c.go", "a/x/b/y/c.go", true},         // both expanding
+		{"a/**/b/**/c.go", "a/b/x/c.go", true},           // first ** matches zero, second ** matches x/
+		{"a/**/b/**/c.go", "a/x/c.go", false},            // no b/ component anywhere
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "matchGitPattern(%q, %q)", tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-4: Single-star must not cross path separators
+// ---------------------------------------------------------------------------
+
+func TestEdgeSingleStarNoCrossSlash(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"*/*.go", "src/main.go", true},       // explicit one-level
+		{"*/*.go", "a/b/main.go", false},      // single * can't cross two slashes
+		{"*/*.go", "main.go", false},          // needs a directory segment
+		{"*.go", "a/b/c.go", true},            // basename-only match (no slash in pattern)
+		{"*.go", "a/b/c.rb", false},           // extension mismatch
+		{"src/*.go", "src/main.go", true},
+		{"src/*.go", "src/sub/main.go", false}, // * can't cross slash
+		{"src/*.go", "src/main.rb", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "matchGitPattern(%q, %q)", tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-5: Character classes
+// ---------------------------------------------------------------------------
+
+func TestEdgeCharClasses(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+		note    string
+	}{
+		{"*.[ch]", "foo.c", true, "c in class"},
+		{"*.[ch]", "foo.h", true, "h in class"},
+		{"*.[ch]", "foo.go", false, "go not in [ch]"},
+		{"*.[ch]", "foo./", false, "slash should not match char class"},
+		{"*.[^ch]", "foo.c", false, "negated [^ch]"},
+		{"*.[^ch]", "foo.g", true, "g not in negated [^ch]"},
+		{"*.[!ch]", "foo.c", false, "negated [!ch]"},
+		{"*.[!ch]", "foo.g", true, "g not in negated [!ch]"},
+		{"*.[a-z]", "foo.c", true, "c in range a-z"},
+		{"*.[a-z]", "foo.C", false, "uppercase C not in a-z"},
+		{"*.[A-Z]", "foo.C", true, "C in range A-Z"},
+		{"*.[0-9]", "foo.3", true, "3 in range 0-9"},
+		{"*.[0-9]", "foo.a", false, "a not in range 0-9"},
+		// Char class should not match path separator
+		{"[a-z]oo.go", "foo.go", true, "f matches [a-z]"},
+		{"[a-z]oo.go", "/oo.go", false, "/ must not match char class"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "%s", tt.note)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-6: Anchored patterns
+// ---------------------------------------------------------------------------
+
+func TestEdgeAnchoredPatterns(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"/Makefile", "Makefile", true},
+		{"/Makefile", "src/Makefile", false},
+		{"/Makefile", "a/b/Makefile", false},
+		{"/vendor/**", "vendor/foo.go", true},
+		{"/vendor/**", "vendor/a/b/c.go", true},
+		{"/vendor/**", "src/vendor/foo.go", false},
+		{"/src/*.go", "src/main.go", true},
+		{"/src/*.go", "src/sub/main.go", false},
+		{"/src/*.go", "other/src/main.go", false},
+		{"/.hidden", ".hidden", true},
+		{"/.hidden", "dir/.hidden", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "matchGitPattern(%q, %q)", tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-7: Basename-only matching (pattern with no slash, not anchored)
+// ---------------------------------------------------------------------------
+
+func TestEdgeBasenameMatching(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"Makefile", "Makefile", true},
+		{"Makefile", "src/Makefile", true},
+		{"Makefile", "a/b/c/Makefile", true},
+		{"Makefile", "MakefileExtra", false},
+		{"*.go", "main.go", true},
+		{"*.go", "src/main.go", true},
+		{"*.go", "a/b/main.go", true},
+		{"*.go", "main.rb", false},
+		{"Dockerfile.*", "Dockerfile.dev", true},
+		{"Dockerfile.*", "src/Dockerfile.prod", true},
+		{"Dockerfile.*", "Dockerfile", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "matchGitPattern(%q, %q)", tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-8: Edge cases for empty/special inputs to matchGitPattern
+// ---------------------------------------------------------------------------
+
+func TestEdgeMatchSpecialInputs(t *testing.T) {
+	// Empty path
+	assert.False(t, matchGitPattern("*.go", ""), "empty path should not match *.go")
+
+	// Empty pattern — filepath.Base("") returns "." so empty pattern vs empty path is non-trivial
+	assert.False(t, matchGitPattern("", "foo.go"), "empty pattern should not match foo.go")
+	// Note: matchGitPattern("","") returns false because filepath.Base("") == "." in Go;
+	// this is a known quirk — an empty pattern in .gitattributes is not meaningful in practice.
+
+	// Just a star — should match any single filename (basename match)
+	assert.True(t, matchGitPattern("*", "foo.go"), "* matches any file")
+	assert.True(t, matchGitPattern("*", "main.rb"), "* matches main.rb")
+
+	// ** alone should match everything
+	assert.True(t, matchGitPattern("**", "foo.go"), "** matches any file")
+	assert.True(t, matchGitPattern("**", "a/b/c.go"), "** matches deep path")
+	assert.True(t, matchGitPattern("**", ""), "** matches empty path")
+
+	// Literal "/" pattern: HasSuffix("/","/") fires first, so it becomes a trailing-slash dir pattern;
+	// the path "" doesn't end with "/" so this returns false.
+	assert.False(t, matchGitPattern("/", ""), "/ pattern is treated as trailing-slash dir pattern, not root anchor")
+
+	// Pattern with special regex chars (should be literal)
+	assert.False(t, matchGitPattern("foo.go", "fooXgo"), ". is literal, not regex wildcard")
+	assert.True(t, matchGitPattern("foo.go", "foo.go"), "literal dot matches literal dot")
+
+	// Pattern with + (should be literal)
+	assert.True(t, matchGitPattern("*.c++", "main.c++"), "c++ extension literal match")
+	assert.False(t, matchGitPattern("*.c++", "main.cpp"), "c++ does not match cpp")
+}
+
+// ---------------------------------------------------------------------------
+// EC-9: Parsing edge cases
+// ---------------------------------------------------------------------------
+
+func TestEdgeParsing(t *testing.T) {
+	t.Run("empty_value", func(t *testing.T) {
+		// linguist-language= with empty value
+		ga, err := ParseGitAttributes([]byte("*.go linguist-language=\n"))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 1)
+		assert.Equal(t, "", ga.rules[0].attrs["linguist-language"])
+	})
+
+	t.Run("value_with_multiple_equals", func(t *testing.T) {
+		// Only split on first =
+		ga, err := ParseGitAttributes([]byte("*.go linguist-language=a=b\n"))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 1)
+		assert.Equal(t, "a=b", ga.rules[0].attrs["linguist-language"])
+	})
+
+	t.Run("double_dash_prefix", func(t *testing.T) {
+		// --linguist-vendored should NOT be treated as -linguist-vendored
+		ga, err := ParseGitAttributes([]byte("*.go --linguist-vendored\n"))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 1)
+		// The attr key should be "-linguist-vendored" (double dash → strip one dash, key="-linguist-vendored")
+		_, hasVendored := ga.rules[0].attrs["linguist-vendored"]
+		assert.False(t, hasVendored, "--linguist-vendored should NOT parse as linguist-vendored=false")
+	})
+
+	t.Run("crlf_line_endings", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.go linguist-language=Go\r\n*.rb linguist-language=Ruby\r\n"))
+		require.NoError(t, err)
+		assert.Len(t, ga.rules, 2)
+		assert.Equal(t, "Go", ga.rules[0].attrs["linguist-language"])
+		assert.Equal(t, "Ruby", ga.rules[1].attrs["linguist-language"])
+	})
+
+	t.Run("inline_comment", func(t *testing.T) {
+		// Inline comments are NOT part of the gitattributes spec — # within a line is not a comment
+		// The parser should treat # as an attribute token
+		ga, err := ParseGitAttributes([]byte("*.go linguist-vendored # comment\n"))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 1)
+		// linguist-vendored should still be parsed
+		assert.Equal(t, "true", ga.rules[0].attrs["linguist-vendored"])
+		// "#" and "comment" are parsed as bare attrs (not ignored)
+		_, hasHash := ga.rules[0].attrs["#"]
+		assert.True(t, hasHash, "inline # is parsed as attribute name (not a comment)")
+	})
+
+	t.Run("tab_separated", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.go\tlinguist-language=Go\n"))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 1)
+		assert.Equal(t, "Go", ga.rules[0].attrs["linguist-language"])
+	})
+
+	t.Run("language_with_special_chars", func(t *testing.T) {
+		// C++ and C# are real language names with special chars
+		ga, err := ParseGitAttributes([]byte("*.cpp linguist-language=C++\n"))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 1)
+		assert.Equal(t, "C++", ga.rules[0].attrs["linguist-language"])
+	})
+
+	t.Run("language_csharp", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.cs linguist-language=C#\n"))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 1)
+		assert.Equal(t, "C#", ga.rules[0].attrs["linguist-language"])
+	})
+
+	t.Run("whitespace_only_line", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("   \t   \n"))
+		require.NoError(t, err)
+		assert.Len(t, ga.rules, 0)
+	})
+
+	t.Run("no_newline_at_end", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.go linguist-language=Go"))
+		require.NoError(t, err)
+		assert.Len(t, ga.rules, 1)
+	})
+
+	t.Run("nul_byte_in_content", func(t *testing.T) {
+		// Should not panic
+		content := []byte("*.go linguist-language=Go\x00\n*.rb linguist-language=Ruby\n")
+		_, err := ParseGitAttributes(content)
+		// Either succeeds or returns an error — must not panic
+		_ = err
+	})
+
+	t.Run("spaces_in_pattern_not_escaped", func(t *testing.T) {
+		// strings.Fields splits on whitespace, so a space in pattern breaks parsing
+		// "path with spaces" → pattern="path", attrs include "with", "spaces", "linguist-vendored"
+		ga, err := ParseGitAttributes([]byte("path with spaces linguist-vendored\n"))
+		require.NoError(t, err)
+		// Pattern is just "path" (first field), rest are parsed as attrs
+		if len(ga.rules) > 0 {
+			assert.Equal(t, "path", ga.rules[0].pattern, "spaces in path break parsing: only 'path' is the pattern")
+		}
+	})
+
+	t.Run("very_many_rules", func(t *testing.T) {
+		// Performance/stability: 1000 rules
+		var sb strings.Builder
+		for i := 0; i < 1000; i++ {
+			sb.WriteString("*.go linguist-language=Go\n")
+		}
+		ga, err := ParseGitAttributes([]byte(sb.String()))
+		require.NoError(t, err)
+		assert.Len(t, ga.rules, 1000)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// EC-10: Attribute semantics — precedence, negation, unknowns
+// ---------------------------------------------------------------------------
+
+func TestEdgeAttributeSemantics(t *testing.T) {
+	t.Run("explicit_false_overrides_default_vendor", func(t *testing.T) {
+		// vendor/ paths are detected as vendor by default
+		// -linguist-vendored should override and force NOT vendor
+		ga, err := ParseGitAttributes([]byte("vendor/** -linguist-vendored\n"))
+		require.NoError(t, err)
+		// Default IsVendor("vendor/foo.go") is true, but the override should flip it
+		assert.False(t, ga.IsVendor("vendor/foo.go"), "-linguist-vendored should override default vendor detection")
+	})
+
+	t.Run("last_rule_wins_for_same_attr", func(t *testing.T) {
+		content := "*.go linguist-language=Ruby\n*.go linguist-language=Go\n"
+		ga, err := ParseGitAttributes([]byte(content))
+		require.NoError(t, err)
+		lang, ok := ga.GetLanguage("main.go")
+		assert.True(t, ok)
+		assert.Equal(t, "Go", lang, "last matching rule should win")
+	})
+
+	t.Run("last_rule_wins_vendor_override", func(t *testing.T) {
+		content := "vendor/** linguist-vendored\nvendor/mine/** -linguist-vendored\n"
+		ga, err := ParseGitAttributes([]byte(content))
+		require.NoError(t, err)
+		assert.False(t, ga.IsVendor("vendor/mine/foo.go"), "later -linguist-vendored should override")
+		assert.True(t, ga.IsVendor("vendor/other/foo.go"), "earlier rule still applies to unoverridden paths")
+	})
+
+	t.Run("different_attrs_from_different_rules", func(t *testing.T) {
+		// Rule 1 sets language, rule 2 sets vendored — both should apply to *.go
+		content := "*.go linguist-language=Go\n*.go linguist-vendored\n"
+		ga, err := ParseGitAttributes([]byte(content))
+		require.NoError(t, err)
+		lang, ok := ga.GetLanguage("main.go")
+		assert.True(t, ok)
+		assert.Equal(t, "Go", lang)
+		assert.True(t, ga.IsVendor("main.go"), "linguist-vendored from rule 2 should also apply")
+	})
+
+	t.Run("rule2_matches_but_has_no_attr_falls_back_to_rule1", func(t *testing.T) {
+		// Rule 1: *.go → language=Go; Rule 2: *.go → vendored (no language attr)
+		// GetLanguage for *.go should find rule2 doesn't have language, then rule1 does
+		content := "*.go linguist-language=Go\n*.go linguist-vendored\n"
+		ga, err := ParseGitAttributes([]byte(content))
+		require.NoError(t, err)
+		lang, ok := ga.GetLanguage("main.go")
+		assert.True(t, ok)
+		assert.Equal(t, "Go", lang, "rule2 matches but has no language attr; rule1's language should be used")
+	})
+
+	t.Run("lowercase_language_alias", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.go linguist-language=go\n"))
+		require.NoError(t, err)
+		lang, ok := ga.GetLanguage("main.go")
+		assert.True(t, ok)
+		assert.Equal(t, "Go", lang, "lowercase alias 'go' should resolve to 'Go'")
+	})
+
+	t.Run("python_alias", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.py linguist-language=python\n"))
+		require.NoError(t, err)
+		lang, ok := ga.GetLanguage("main.py")
+		assert.True(t, ok)
+		assert.Equal(t, "Python", lang)
+	})
+
+	t.Run("unknown_language_returned_as_is", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.xyz linguist-language=MyFakeLang9000\n"))
+		require.NoError(t, err)
+		lang, ok := ga.GetLanguage("test.xyz")
+		assert.True(t, ok, "GetLanguage should still return true for unknown language")
+		assert.Equal(t, "MyFakeLang9000", lang, "unknown lang returned as-is")
+	})
+
+	t.Run("empty_language_value", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.go linguist-language=\n"))
+		require.NoError(t, err)
+		lang, ok := ga.GetLanguage("main.go")
+		// Empty string: alias resolution will fail; should return "" as-is and true
+		assert.True(t, ok, "even empty lang value returns true (override exists)")
+		_ = lang // could be "" or resolved
+	})
+
+	t.Run("is_detectable_no_fallback", func(t *testing.T) {
+		// No rules → IsDetectable returns false (no default fallback for programming langs)
+		ga, err := ParseGitAttributes([]byte(""))
+		require.NoError(t, err)
+		assert.False(t, ga.IsDetectable("main.go"), "IsDetectable with no rules returns false (no fallback)")
+		assert.False(t, ga.IsDetectable("schema.sql"), "IsDetectable with no rules returns false for SQL")
+	})
+
+	t.Run("vendored_arbitrary_value", func(t *testing.T) {
+		// linguist-vendored=anything (not "false") should be treated as true
+		ga, err := ParseGitAttributes([]byte("*.go linguist-vendored=maybe\n"))
+		require.NoError(t, err)
+		assert.True(t, ga.IsVendor("main.go"), "any value other than 'false' is treated as vendored")
+	})
+
+	t.Run("empty_gitattributes_fallback", func(t *testing.T) {
+		ga := GitAttributes{}
+		// All methods should fall back to defaults
+		assert.Equal(t, IsVendor("vendor/foo.go"), ga.IsVendor("vendor/foo.go"), "empty attrs falls back to IsVendor")
+		assert.Equal(t, IsDocumentation("docs/guide.md"), ga.IsDocumentation("docs/guide.md"), "empty attrs falls back to IsDocumentation")
+		assert.Equal(t, IsGenerated("foo_generated.go", nil), ga.IsGenerated("foo_generated.go", nil), "empty attrs falls back to IsGenerated")
+		assert.False(t, ga.IsDetectable("main.go"), "IsDetectable with no rules is always false")
+		_, ok := ga.GetLanguage("main.go")
+		assert.False(t, ok, "GetLanguage with no rules returns false")
+	})
+
+	t.Run("multi_attr_same_line_both_apply", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.pb.go linguist-generated linguist-vendored\n"))
+		require.NoError(t, err)
+		assert.True(t, ga.IsGenerated("foo.pb.go", nil))
+		assert.True(t, ga.IsVendor("foo.pb.go"))
+	})
+
+	t.Run("negation_of_multi_attr", func(t *testing.T) {
+		content := "*.pb.go linguist-generated linguist-vendored\nspecial.pb.go -linguist-generated -linguist-vendored\n"
+		ga, err := ParseGitAttributes([]byte(content))
+		require.NoError(t, err)
+		assert.False(t, ga.IsGenerated("special.pb.go", nil), "last rule negates generated")
+		assert.False(t, ga.IsVendor("special.pb.go"), "last rule negates vendored")
+		assert.True(t, ga.IsGenerated("other.pb.go", nil), "other files still match first rule")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// EC-11: matchGitPattern robustness — should not panic on pathological input
+// ---------------------------------------------------------------------------
+
+func TestEdgeMatchPatternNoPanic(t *testing.T) {
+	pathological := []struct{ pattern, path string }{
+		{"[", "foo"},
+		{"[]", "foo"},
+		{"[!]", "foo"},
+		{"[^]", "foo"},
+		{"[a-", "foo"},
+		{"[-]", "-"},
+		{"[---]", "-"},
+		{"***", "foo.go"},
+		{"****", "a/b/c"},
+		{"**/**", "a/b/c"},
+		{"**/**/**", "a/b/c"},
+		{"[\\]", "\\"},
+		{"[abc", "a"},
+		{"a[b", "ab"},
+	}
+
+	for _, tt := range pathological {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			// Should not panic; result is don't care
+			assert.NotPanics(t, func() {
+				_ = matchGitPattern(tt.pattern, tt.path)
+			})
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-12: Real-world .gitattributes patterns from major open source projects
+// ---------------------------------------------------------------------------
+
+func TestEdgeRealWorldPatterns(t *testing.T) {
+	// Patterns extracted from real repositories
+	content := `
+# Kubernetes-style
+vendor/** linguist-vendored
+*.generated.go linguist-generated
+zz_generated*.go linguist-generated
+staging/src/** linguist-vendored
+
+# Tensorflow-style
+tensorflow/core/api_def/base_api/** linguist-documentation
+*.pb.go linguist-generated
+third_party/** linguist-vendored
+
+# Rails-style
+app/assets/javascripts/cable.js linguist-generated
+db/schema.rb linguist-generated
+Gemfile.lock linguist-generated
+
+# Custom language overrides
+Podfile linguist-language=Ruby
+*.podspec linguist-language=Ruby
+Fastfile linguist-language=Ruby
+Dangerfile linguist-language=Ruby
+*.jbuilder linguist-language=Ruby
+`
+
+	ga, err := ParseGitAttributes([]byte(content))
+	require.NoError(t, err)
+
+	// Kubernetes patterns
+	assert.True(t, ga.IsVendor("vendor/k8s.io/client-go/rest/client.go"))
+	assert.True(t, ga.IsVendor("vendor/github.com/pkg/errors/errors.go"))
+	assert.True(t, ga.IsGenerated("pkg/apis/core/v1/zz_generated.conversion.go", nil))
+	assert.True(t, ga.IsGenerated("pkg/apis/core/v1/types.generated.go", nil))
+	assert.True(t, ga.IsVendor("staging/src/k8s.io/apimachinery/pkg/api.go"))
+
+	// Tensorflow patterns
+	assert.True(t, ga.IsVendor("third_party/protobuf/src/google/protobuf/any.proto"))
+	assert.True(t, ga.IsGenerated("tensorflow/go/op/wrappers.pb.go", nil))
+	assert.True(t, ga.IsDocumentation("tensorflow/core/api_def/base_api/api_def_Abs.pbtxt"))
+
+	// Language overrides
+	lang, ok := ga.GetLanguage("Podfile")
+	assert.True(t, ok)
+	assert.Equal(t, "Ruby", lang)
+
+	lang, ok = ga.GetLanguage("MyApp.podspec")
+	assert.True(t, ok)
+	assert.Equal(t, "Ruby", lang)
+
+	lang, ok = ga.GetLanguage("Fastfile")
+	assert.True(t, ok)
+	assert.Equal(t, "Ruby", lang)
+
+	lang, ok = ga.GetLanguage("app/views/users/index.jbuilder")
+	assert.True(t, ok)
+	assert.Equal(t, "Ruby", lang)
+}
+
+// ---------------------------------------------------------------------------
+// EC-13: linguist-detectable semantics
+// ---------------------------------------------------------------------------
+
+func TestEdgeDetectable(t *testing.T) {
+	t.Run("sql_made_detectable", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.sql linguist-detectable\n"))
+		require.NoError(t, err)
+		assert.True(t, ga.IsDetectable("schema.sql"))
+		assert.True(t, ga.IsDetectable("migrations/001_init.sql"))
+		assert.False(t, ga.IsDetectable("main.go"), "go files not in rule are not detectable")
+	})
+
+	t.Run("detectable_then_not", func(t *testing.T) {
+		content := "*.sql linguist-detectable\nexception.sql -linguist-detectable\n"
+		ga, err := ParseGitAttributes([]byte(content))
+		require.NoError(t, err)
+		assert.False(t, ga.IsDetectable("exception.sql"), "explicitly not detectable")
+		assert.True(t, ga.IsDetectable("other.sql"), "other sql files still detectable")
+	})
+
+	t.Run("html_made_detectable", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.html linguist-detectable\n"))
+		require.NoError(t, err)
+		assert.True(t, ga.IsDetectable("index.html"))
+	})
+}
+
+// ---------------------------------------------------------------------------
+// EC-14: Question-mark wildcard edge cases
+// ---------------------------------------------------------------------------
+
+func TestEdgeQuestionMark(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"?.go", "a.go", true},
+		{"?.go", "ab.go", false},      // too long
+		{"?.go", ".go", false},        // too short (0 chars before .)
+		{"?.go", "/.go", false},       // ? doesn't match /
+		{"??.go", "ab.go", true},
+		{"??.go", "a.go", false},
+		{"a?.go", "ab.go", true},
+		{"a?.go", "a/.go", false},     // ? doesn't match /
+		{"a?.go", "abc.go", false},    // pattern expects exactly 1 char after a
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "matchGitPattern(%q, %q)", tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-15: Interaction between getAttr reverse-iteration and multi-attr rules
+// ---------------------------------------------------------------------------
+
+func TestEdgeGetAttrPrecedence(t *testing.T) {
+	// Rule 1: *.go → language=Go, vendored=true
+	// Rule 2: *.go → language=Ruby  (no vendored)
+	// For main.go:
+	//   language → rule2 wins (last match with this attr) → Ruby
+	//   vendored → rule2 has no vendored, rule1 has vendored=true → true
+	content := "*.go linguist-language=Go linguist-vendored\n*.go linguist-language=Ruby\n"
+	ga, err := ParseGitAttributes([]byte(content))
+	require.NoError(t, err)
+
+	lang, ok := ga.GetLanguage("main.go")
+	assert.True(t, ok)
+	assert.Equal(t, "Ruby", lang, "last rule with language attr wins")
+
+	assert.True(t, ga.IsVendor("main.go"), "rule1's vendored attr applies since rule2 doesn't have it")
+}
+
+// ---------------------------------------------------------------------------
+// EC-16: Very deep paths and complex ** expansion
+// ---------------------------------------------------------------------------
+
+func TestEdgeDeepPaths(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		{"**/*.go", "a/b/c/d/e/f/g/h/i/j/main.go", true},
+		{"vendor/**", "vendor/a/b/c/d/e/f/g/h/i/main.go", true},
+		{"/vendor/**", "vendor/a/b/c/d/e/f.go", true},
+		{"src/**/pkg/**/main.go", "src/a/b/c/pkg/d/e/f/main.go", true},
+		{"src/**/pkg/**/main.go", "src/pkg/main.go", true},
+		{"*.go", "a/b/c/d/e/f/g/h/i/j/main.go", true}, // basename match
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "matchGitPattern(%q, %q)", tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-17: ParseGitAttributes returns zero rules for pattern-only lines
+// ---------------------------------------------------------------------------
+
+func TestEdgePatternOnlyLines(t *testing.T) {
+	// Lines with only a pattern and no attributes should be silently ignored
+	inputs := []string{
+		"*.go\n",
+		"/vendor/**\n",
+		"Makefile\n",
+		"**\n",
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			ga, err := ParseGitAttributes([]byte(input))
+			require.NoError(t, err)
+			assert.Len(t, ga.rules, 0, "pattern-only line '%s' should produce 0 rules", input)
+		})
+	}
+}

--- a/gitattributes_edge_test.go
+++ b/gitattributes_edge_test.go
@@ -50,8 +50,10 @@ func TestEdgeDoubleStarPathBoundary(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestEdgeTrailingSlashDirectory verifies that a trailing-slash pattern
-// (e.g. "vendor/") matches files INSIDE that directory, not just the literal
-// path ending in "/".
+// (e.g. "vendor/") only matches directory paths (ending with "/"), NOT
+// files inside the directory. This differs from .gitignore behavior.
+// The Git docs call trailing "/" in .gitattributes "pointless" — use
+// "vendor/**" instead.
 func TestEdgeTrailingSlashDirectory(t *testing.T) {
 	tests := []struct {
 		pattern string
@@ -59,14 +61,14 @@ func TestEdgeTrailingSlashDirectory(t *testing.T) {
 		want    bool
 		note    string
 	}{
-		// Files inside vendor/ should match vendor/ pattern
-		{"vendor/", "vendor/foo.go", true, "files in vendor/ should be matched"},
-		{"vendor/", "vendor/lib/bar.go", true, "nested files in vendor/ should be matched"},
-		{"vendor/", "vendor/", true, "the directory itself should match"},
+		// Trailing-slash only matches directory paths, not files inside
+		{"vendor/", "vendor/foo.go", false, "trailing-slash does NOT match files inside directory"},
+		{"vendor/", "vendor/lib/bar.go", false, "trailing-slash does NOT match nested files"},
+		{"vendor/", "vendor/", true, "the directory path itself should match"},
 
-		// Files outside should not match
-		{"vendor/", "src/vendor/foo.go", false, "files in src/vendor/ should not match anchored vendor/"},
-		{"vendor/", "notvendor/foo.go", false, "files in notvendor/ should not match vendor/"},
+		// These should also not match
+		{"vendor/", "src/vendor/foo.go", false, "files in src/vendor/ should not match"},
+		{"vendor/", "notvendor/foo.go", false, "files in notvendor/ should not match"},
 		{"vendor/", "vendor", false, "bare 'vendor' without trailing slash should not match"},
 	}
 
@@ -83,11 +85,15 @@ func TestEdgeTrailingSlashDirectory(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 // TestEdgeTrailingSlashWithGlob verifies that trailing-slash patterns
-// containing globs (e.g. "**/vendor/") still glob-match, not literal-match.
+// do NOT match file paths, even when combined with globs.
+// In .gitattributes, trailing "/" is "pointless" per Git docs.
 func TestEdgeTrailingSlashWithGlob(t *testing.T) {
-	// "**/vendor/" should match files inside any vendor/ directory at any depth
-	assert.True(t, matchGitPattern("**/vendor/", "a/vendor/foo.go"),
-		"**/vendor/ should glob-match nested vendor dirs")
+	// "**/vendor/" should NOT match file paths — trailing slash means directory-only
+	assert.False(t, matchGitPattern("**/vendor/", "a/vendor/foo.go"),
+		"**/vendor/ should not match file paths")
+	// But should match a directory path
+	assert.True(t, matchGitPattern("**/vendor/", "a/vendor/"),
+		"**/vendor/ should match directory paths")
 }
 
 // ---------------------------------------------------------------------------

--- a/gitattributes_edge_test.go
+++ b/gitattributes_edge_test.go
@@ -88,20 +88,20 @@ func TestEdgeDoubleStarMiddle(t *testing.T) {
 		path    string
 		want    bool
 	}{
-		{"src/**/test.go", "src/test.go", true},          // zero dirs
-		{"src/**/test.go", "src/a/test.go", true},         // one dir
-		{"src/**/test.go", "src/a/b/test.go", true},       // two dirs
-		{"src/**/test.go", "src/a/b/c/test.go", true},     // three dirs
-		{"src/**/test.go", "test.go", false},              // missing src prefix
-		{"src/**/test.go", "other/a/test.go", false},      // wrong top dir
-		{"src/**/*.go", "src/foo.go", true},               // zero dirs
-		{"src/**/*.go", "src/pkg/foo.go", true},           // one dir
-		{"src/**/*.go", "src/pkg/sub/foo.go", true},       // nested
-		{"src/**/*.go", "pkg/foo.go", false},              // missing src
-		{"a/**/b/**/c.go", "a/b/c.go", true},              // two double-stars, both match zero
-		{"a/**/b/**/c.go", "a/x/b/y/c.go", true},         // both expanding
-		{"a/**/b/**/c.go", "a/b/x/c.go", true},           // first ** matches zero, second ** matches x/
-		{"a/**/b/**/c.go", "a/x/c.go", false},            // no b/ component anywhere
+		{"src/**/test.go", "src/test.go", true},       // zero dirs
+		{"src/**/test.go", "src/a/test.go", true},     // one dir
+		{"src/**/test.go", "src/a/b/test.go", true},   // two dirs
+		{"src/**/test.go", "src/a/b/c/test.go", true}, // three dirs
+		{"src/**/test.go", "test.go", false},          // missing src prefix
+		{"src/**/test.go", "other/a/test.go", false},  // wrong top dir
+		{"src/**/*.go", "src/foo.go", true},           // zero dirs
+		{"src/**/*.go", "src/pkg/foo.go", true},       // one dir
+		{"src/**/*.go", "src/pkg/sub/foo.go", true},   // nested
+		{"src/**/*.go", "pkg/foo.go", false},          // missing src
+		{"a/**/b/**/c.go", "a/b/c.go", true},          // two double-stars, both match zero
+		{"a/**/b/**/c.go", "a/x/b/y/c.go", true},      // both expanding
+		{"a/**/b/**/c.go", "a/b/x/c.go", true},        // first ** matches zero, second ** matches x/
+		{"a/**/b/**/c.go", "a/x/c.go", false},         // no b/ component anywhere
 	}
 
 	for _, tt := range tests {
@@ -122,11 +122,11 @@ func TestEdgeSingleStarNoCrossSlash(t *testing.T) {
 		path    string
 		want    bool
 	}{
-		{"*/*.go", "src/main.go", true},       // explicit one-level
-		{"*/*.go", "a/b/main.go", false},      // single * can't cross two slashes
-		{"*/*.go", "main.go", false},          // needs a directory segment
-		{"*.go", "a/b/c.go", true},            // basename-only match (no slash in pattern)
-		{"*.go", "a/b/c.rb", false},           // extension mismatch
+		{"*/*.go", "src/main.go", true},  // explicit one-level
+		{"*/*.go", "a/b/main.go", false}, // single * can't cross two slashes
+		{"*/*.go", "main.go", false},     // needs a directory segment
+		{"*.go", "a/b/c.go", true},       // basename-only match (no slash in pattern)
+		{"*.go", "a/b/c.rb", false},      // extension mismatch
 		{"src/*.go", "src/main.go", true},
 		{"src/*.go", "src/sub/main.go", false}, // * can't cross slash
 		{"src/*.go", "src/main.rb", false},
@@ -284,7 +284,7 @@ func TestEdgeParsing(t *testing.T) {
 		ga, err := ParseGitAttributes([]byte("*.go linguist-language=\n"))
 		require.NoError(t, err)
 		require.Len(t, ga.rules, 1)
-		assert.Equal(t, "", ga.rules[0].attrs["linguist-language"])
+		requireGitAttributeValue(t, ga.rules[0].attrs, "linguist-language", gitAttributeValue{kind: gitAttributeValueString, value: ""})
 	})
 
 	t.Run("value_with_multiple_equals", func(t *testing.T) {
@@ -292,7 +292,7 @@ func TestEdgeParsing(t *testing.T) {
 		ga, err := ParseGitAttributes([]byte("*.go linguist-language=a=b\n"))
 		require.NoError(t, err)
 		require.Len(t, ga.rules, 1)
-		assert.Equal(t, "a=b", ga.rules[0].attrs["linguist-language"])
+		requireGitAttributeValue(t, ga.rules[0].attrs, "linguist-language", gitAttributeValue{kind: gitAttributeValueString, value: "a=b"})
 	})
 
 	t.Run("double_dash_prefix", func(t *testing.T) {
@@ -309,8 +309,8 @@ func TestEdgeParsing(t *testing.T) {
 		ga, err := ParseGitAttributes([]byte("*.go linguist-language=Go\r\n*.rb linguist-language=Ruby\r\n"))
 		require.NoError(t, err)
 		assert.Len(t, ga.rules, 2)
-		assert.Equal(t, "Go", ga.rules[0].attrs["linguist-language"])
-		assert.Equal(t, "Ruby", ga.rules[1].attrs["linguist-language"])
+		requireGitAttributeValue(t, ga.rules[0].attrs, "linguist-language", gitAttributeValue{kind: gitAttributeValueString, value: "Go"})
+		requireGitAttributeValue(t, ga.rules[1].attrs, "linguist-language", gitAttributeValue{kind: gitAttributeValueString, value: "Ruby"})
 	})
 
 	t.Run("inline_comment", func(t *testing.T) {
@@ -320,7 +320,7 @@ func TestEdgeParsing(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, ga.rules, 1)
 		// linguist-vendored should still be parsed
-		assert.Equal(t, "true", ga.rules[0].attrs["linguist-vendored"])
+		requireGitAttributeValue(t, ga.rules[0].attrs, "linguist-vendored", gitAttributeValue{kind: gitAttributeValueSet})
 		// "#" and "comment" are parsed as bare attrs (not ignored)
 		_, hasHash := ga.rules[0].attrs["#"]
 		assert.True(t, hasHash, "inline # is parsed as attribute name (not a comment)")
@@ -330,7 +330,7 @@ func TestEdgeParsing(t *testing.T) {
 		ga, err := ParseGitAttributes([]byte("*.go\tlinguist-language=Go\n"))
 		require.NoError(t, err)
 		require.Len(t, ga.rules, 1)
-		assert.Equal(t, "Go", ga.rules[0].attrs["linguist-language"])
+		requireGitAttributeValue(t, ga.rules[0].attrs, "linguist-language", gitAttributeValue{kind: gitAttributeValueString, value: "Go"})
 	})
 
 	t.Run("language_with_special_chars", func(t *testing.T) {
@@ -338,14 +338,14 @@ func TestEdgeParsing(t *testing.T) {
 		ga, err := ParseGitAttributes([]byte("*.cpp linguist-language=C++\n"))
 		require.NoError(t, err)
 		require.Len(t, ga.rules, 1)
-		assert.Equal(t, "C++", ga.rules[0].attrs["linguist-language"])
+		requireGitAttributeValue(t, ga.rules[0].attrs, "linguist-language", gitAttributeValue{kind: gitAttributeValueString, value: "C++"})
 	})
 
 	t.Run("language_csharp", func(t *testing.T) {
 		ga, err := ParseGitAttributes([]byte("*.cs linguist-language=C#\n"))
 		require.NoError(t, err)
 		require.Len(t, ga.rules, 1)
-		assert.Equal(t, "C#", ga.rules[0].attrs["linguist-language"])
+		requireGitAttributeValue(t, ga.rules[0].attrs, "linguist-language", gitAttributeValue{kind: gitAttributeValueString, value: "C#"})
 	})
 
 	t.Run("whitespace_only_line", func(t *testing.T) {
@@ -681,14 +681,14 @@ func TestEdgeQuestionMark(t *testing.T) {
 		want    bool
 	}{
 		{"?.go", "a.go", true},
-		{"?.go", "ab.go", false},      // too long
-		{"?.go", ".go", false},        // too short (0 chars before .)
-		{"?.go", "/.go", false},       // ? doesn't match /
+		{"?.go", "ab.go", false}, // too long
+		{"?.go", ".go", false},   // too short (0 chars before .)
+		{"?.go", "/.go", false},  // ? doesn't match /
 		{"??.go", "ab.go", true},
 		{"??.go", "a.go", false},
 		{"a?.go", "ab.go", true},
-		{"a?.go", "a/.go", false},     // ? doesn't match /
-		{"a?.go", "abc.go", false},    // pattern expects exactly 1 char after a
+		{"a?.go", "a/.go", false},  // ? doesn't match /
+		{"a?.go", "abc.go", false}, // pattern expects exactly 1 char after a
 	}
 
 	for _, tt := range tests {

--- a/gitattributes_edge_test.go
+++ b/gitattributes_edge_test.go
@@ -185,11 +185,69 @@ func TestEdgeCharClasses(t *testing.T) {
 		// Char class should not match path separator
 		{"[a-z]oo.go", "foo.go", true, "f matches [a-z]"},
 		{"[a-z]oo.go", "/oo.go", false, "/ must not match char class"},
+		// POSIX named character classes
+		{"[[:alpha:]]oo.go", "foo.go", true, "f in [:alpha:]"},
+		{"[[:alpha:]]oo.go", "3oo.go", false, "3 not in [:alpha:]"},
+		{"[[:digit:]]*.txt", "3file.txt", true, "3 in [:digit:]"},
+		{"[[:digit:]]*.txt", "afile.txt", false, "a not in [:digit:]"},
+		{"*.[[:upper:]]", "foo.C", true, "C in [:upper:]"},
+		{"*.[[:upper:]]", "foo.c", false, "c not in [:upper:]"},
+		{"*.[[:lower:]]", "foo.c", true, "c in [:lower:]"},
+		{"*.[[:lower:]]", "foo.C", false, "C not in [:lower:]"},
+		{"[[:alnum:]]*.go", "a.go", true, "a in [:alnum:]"},
+		{"[[:alnum:]]*.go", "9.go", true, "9 in [:alnum:]"},
+		{"[[:alnum:]]*.go", "-.go", false, "- not in [:alnum:]"},
+		{"[[:xdigit:]]", "a", true, "a in [:xdigit:]"},
+		{"[[:xdigit:]]", "F", true, "F in [:xdigit:]"},
+		{"[[:xdigit:]]", "g", false, "g not in [:xdigit:]"},
+		{"[[:blank:]]", " ", true, "space in [:blank:]"},
+		{"[[:blank:]]", "\t", true, "tab in [:blank:]"},
+		{"[[:blank:]]", "a", false, "a not in [:blank:]"},
+		// Negated POSIX class
+		{"[^[:digit:]]*.go", "a.go", true, "a not in negated [:digit:]"},
+		{"[^[:digit:]]*.go", "3.go", false, "3 in negated [:digit:]"},
+		// POSIX class combined with other chars in bracket
+		{"[[:digit:]ab]", "a", true, "a in [:digit:] + ab"},
+		{"[[:digit:]ab]", "5", true, "5 in [:digit:] + ab"},
+		{"[[:digit:]ab]", "c", false, "c not in [:digit:] + ab"},
+		// Unknown POSIX class makes entire pattern non-matching
+		{"[[:spaci:]]", " ", false, "unknown class rejects match"},
+		{"[[:digit:][:spaci:]]", "5", false, "unknown class in mix rejects match"},
+		{"[^[:spaci:]]", "a", false, "negated unknown class rejects match"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
 			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "%s", tt.note)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-5b: POSIX class validation
+// ---------------------------------------------------------------------------
+
+func TestHasValidPOSIXClasses(t *testing.T) {
+	tests := []struct {
+		class string
+		want  bool
+		note  string
+	}{
+		{"", true, "empty class string"},
+		{"a-z", true, "no POSIX classes"},
+		{"[:alpha:]", true, "single valid class"},
+		{"[:digit:]ab", true, "valid class with trailing chars"},
+		{"[:digit:][:alpha:]", true, "two valid classes"},
+		{"[:spaci:]", false, "unknown class"},
+		{"[:digit:][:spaci:]", false, "valid + unknown mix"},
+		{"[:", true, "incomplete opening, not a POSIX class"},
+		{"[:alpha", true, "no closing :], not a POSIX class"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.class, func(t *testing.T) {
+			got := hasValidPOSIXClasses(tt.class)
 			assert.Equal(t, tt.want, got, "%s", tt.note)
 		})
 	}

--- a/gitattributes_edge_test.go
+++ b/gitattributes_edge_test.go
@@ -67,7 +67,7 @@ func TestEdgeTrailingSlashDirectory(t *testing.T) {
 		{"vendor/", "vendor/", true, "the directory path itself should match"},
 
 		// These should also not match
-		{"vendor/", "src/vendor/foo.go", false, "files in src/vendor/ should not match"},
+		{"vendor/", "src/vendor/foo.go", false, "not a directory path, trailing-slash only matches dirs"},
 		{"vendor/", "notvendor/foo.go", false, "files in notvendor/ should not match"},
 		{"vendor/", "vendor", false, "bare 'vendor' without trailing slash should not match"},
 	}

--- a/gitattributes_edge_test.go
+++ b/gitattributes_edge_test.go
@@ -477,12 +477,14 @@ func TestEdgeAttributeSemantics(t *testing.T) {
 		_ = lang // could be "" or resolved
 	})
 
-	t.Run("is_detectable_no_fallback", func(t *testing.T) {
-		// No rules → IsDetectable returns false (no default fallback for programming langs)
+	t.Run("is_detectable_no_override", func(t *testing.T) {
+		// No rules → IsDetectable returns (false, false) — no override
 		ga, err := ParseGitAttributes([]byte(""))
 		require.NoError(t, err)
-		assert.False(t, ga.IsDetectable("main.go"), "IsDetectable with no rules returns false (no fallback)")
-		assert.False(t, ga.IsDetectable("schema.sql"), "IsDetectable with no rules returns false for SQL")
+		_, ok := ga.IsDetectable("main.go")
+		assert.False(t, ok, "IsDetectable with no rules returns no override")
+		_, ok = ga.IsDetectable("schema.sql")
+		assert.False(t, ok, "IsDetectable with no rules returns no override for SQL")
 	})
 
 	t.Run("vendored_arbitrary_value", func(t *testing.T) {
@@ -498,8 +500,9 @@ func TestEdgeAttributeSemantics(t *testing.T) {
 		assert.Equal(t, IsVendor("vendor/foo.go"), ga.IsVendor("vendor/foo.go"), "empty attrs falls back to IsVendor")
 		assert.Equal(t, IsDocumentation("docs/guide.md"), ga.IsDocumentation("docs/guide.md"), "empty attrs falls back to IsDocumentation")
 		assert.Equal(t, IsGenerated("foo_generated.go", nil), ga.IsGenerated("foo_generated.go", nil), "empty attrs falls back to IsGenerated")
-		assert.False(t, ga.IsDetectable("main.go"), "IsDetectable with no rules is always false")
-		_, ok := ga.GetLanguage("main.go")
+		_, ok := ga.IsDetectable("main.go")
+		assert.False(t, ok, "IsDetectable with no rules returns no override")
+		_, ok = ga.GetLanguage("main.go")
 		assert.False(t, ok, "GetLanguage with no rules returns false")
 	})
 
@@ -624,23 +627,46 @@ func TestEdgeDetectable(t *testing.T) {
 	t.Run("sql_made_detectable", func(t *testing.T) {
 		ga, err := ParseGitAttributes([]byte("*.sql linguist-detectable\n"))
 		require.NoError(t, err)
-		assert.True(t, ga.IsDetectable("schema.sql"))
-		assert.True(t, ga.IsDetectable("migrations/001_init.sql"))
-		assert.False(t, ga.IsDetectable("main.go"), "go files not in rule are not detectable")
+		val, ok := ga.IsDetectable("schema.sql")
+		assert.True(t, ok, "should have override")
+		assert.True(t, val, "should be detectable")
+		val, ok = ga.IsDetectable("migrations/001_init.sql")
+		assert.True(t, ok)
+		assert.True(t, val)
+		_, ok = ga.IsDetectable("main.go")
+		assert.False(t, ok, "go files not in rule have no override")
 	})
 
 	t.Run("detectable_then_not", func(t *testing.T) {
 		content := "*.sql linguist-detectable\nexception.sql -linguist-detectable\n"
 		ga, err := ParseGitAttributes([]byte(content))
 		require.NoError(t, err)
-		assert.False(t, ga.IsDetectable("exception.sql"), "explicitly not detectable")
-		assert.True(t, ga.IsDetectable("other.sql"), "other sql files still detectable")
+		val, ok := ga.IsDetectable("exception.sql")
+		assert.True(t, ok, "should have override")
+		assert.False(t, val, "explicitly not detectable")
+		val, ok = ga.IsDetectable("other.sql")
+		assert.True(t, ok)
+		assert.True(t, val, "other sql files still detectable")
 	})
 
 	t.Run("html_made_detectable", func(t *testing.T) {
 		ga, err := ParseGitAttributes([]byte("*.html linguist-detectable\n"))
 		require.NoError(t, err)
-		assert.True(t, ga.IsDetectable("index.html"))
+		val, ok := ga.IsDetectable("index.html")
+		assert.True(t, ok)
+		assert.True(t, val)
+	})
+
+	t.Run("programming_language_made_undetectable", func(t *testing.T) {
+		// -linguist-detectable can exclude a programming language from stats
+		ga, err := ParseGitAttributes([]byte("tools/*.py -linguist-detectable\n"))
+		require.NoError(t, err)
+		val, ok := ga.IsDetectable("tools/export.py")
+		assert.True(t, ok, "should have override")
+		assert.False(t, val, "-linguist-detectable should exclude from stats")
+		// Other py files have no override
+		_, ok = ga.IsDetectable("src/main.py")
+		assert.False(t, ok, "no override for src/main.py")
 	})
 }
 

--- a/gitattributes_edge_test.go
+++ b/gitattributes_edge_test.go
@@ -79,6 +79,18 @@ func TestEdgeTrailingSlashDirectory(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// EC-2b: Trailing-slash with glob in dir part
+// ---------------------------------------------------------------------------
+
+// TestEdgeTrailingSlashWithGlob verifies that trailing-slash patterns
+// containing globs (e.g. "**/vendor/") still glob-match, not literal-match.
+func TestEdgeTrailingSlashWithGlob(t *testing.T) {
+	// "**/vendor/" should match files inside any vendor/ directory at any depth
+	assert.True(t, matchGitPattern("**/vendor/", "a/vendor/foo.go"),
+		"**/vendor/ should glob-match nested vendor dirs")
+}
+
+// ---------------------------------------------------------------------------
 // EC-3: Double-star in middle of pattern
 // ---------------------------------------------------------------------------
 

--- a/gitattributes_edge_test.go
+++ b/gitattributes_edge_test.go
@@ -842,3 +842,161 @@ func TestEdgePatternOnlyLines(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// EC-18: Backslash escaping in patterns
+// All expected values verified against Git's test-tool wildmatch binary.
+// ---------------------------------------------------------------------------
+
+func TestEdgeBackslashEscaping(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+		note    string
+	}{
+		{`foo\*`, "foo*", true, `\* matches literal *`},
+		{`foo\*`, "foobar", false, `\* does not match wildcard`},
+		{`foo\*bar`, "foobar", false, `\* requires literal * between foo and bar`},
+		{`foo\*bar`, "foo*bar", true, `\* matches literal * in text`},
+		{`\a\b\c`, "abc", true, `escape of non-special chars`},
+		{`foo\\`, `foo\`, true, `\\ matches literal \`},
+		{`foo\`, "foo", false, `trailing \ is invalid`},
+		{`\[ab]`, "[ab]", true, `\[ matches literal [`},
+		{`\?a\?b`, "?a?b", true, `\? matches literal ?`},
+		{`\#readme`, "#readme", true, `\# matches literal #`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := globMatch(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "%s: globMatch(%q, %q)", tt.note, tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-19: ** boundary rules — ** not at path boundary treated as single *
+// All expected values verified against Git's test-tool wildmatch binary.
+// ---------------------------------------------------------------------------
+
+func TestEdgeDoubleStarBoundary(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+		note    string
+	}{
+		// ** NOT at boundary → treated as single * (cannot cross /)
+		{"foo**bar", "foobazbar", true, "** as *: matches baz substring"},
+		{"foo**bar", "foo/baz/bar", false, "** as *: can't cross /"},
+		{"a**f", "af", true, "** as *: matches empty"},
+		{"a**f", "axf", true, "** as *: matches x"},
+		{"a**f", "a/f", false, "** as *: can't cross /"},
+		{"a**f", "a/b/f", false, "** as *: can't cross multiple /"},
+		{"foo**/bar", "foo/bar", true, "foo** not at boundary, * matches empty before /"},
+		{"foo**/bar", "foo/baz/bar", false, "foo** as *: can't cross /"},
+		{"foo/**arr", "foo/bba/arr", false, "**arr not at boundary: can't cross /"},
+		{"bar**", "bar/baz", false, "bar** not at boundary: can't cross /"},
+
+		// ** AT boundary → crosses / (should still work)
+		{"**/foo", "foo", true, "** at start: matches root"},
+		{"**/foo", "a/b/foo", true, "** at start: matches deep"},
+		{"foo/**", "foo/bar/baz", true, "** at end: matches deep"},
+		{"foo/**/bar", "foo/bar", true, "** in middle: zero dirs"},
+		{"foo/**/bar", "foo/a/b/bar", true, "** in middle: multiple dirs"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := globMatch(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "%s: globMatch(%q, %q)", tt.note, tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-20: ] as literal first character in bracket class
+// All expected values verified against Git's test-tool wildmatch binary.
+// ---------------------------------------------------------------------------
+
+func TestEdgeBracketLiteralClose(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+		note    string
+	}{
+		{"a[]]b", "a]b", true, "] after [ is literal class member (spec #24)"},
+		{"a[]-]b", "a-b", true, "class {], -} matches - (spec #25)"},
+		{"a[]-]b", "a]b", true, "class {], -} matches ] (spec #26)"},
+		{"a[]-]b", "aab", false, "a not in {], -} (spec #27)"},
+		{"a[]a-]b", "aab", true, "class {], a, -} matches a (spec #28)"},
+		{"[!]-]", "a", true, "negated {], -}: a is not in set (spec #61)"},
+		{"[!]-]", "]", false, "negated {], -}: ] is in set (spec #60)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := globMatch(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "%s: globMatch(%q, %q)", tt.note, tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-21: Escape sequences in character classes
+// All expected values verified against Git's test-tool wildmatch binary.
+// ---------------------------------------------------------------------------
+
+func TestEdgeBracketEscape(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+		note    string
+	}{
+		{`[\]]`, "]", true, `\] is literal ] in class (spec #99)`},
+		{`[\]]`, `\`, false, `\ does not match [\]] (spec #101)`},
+		{`[\\\\]`, `\`, true, `\\\\ in class matches \ (spec #128)`},
+		{`[\1-\3]`, "2", true, `escaped range \1-\3 matches 2 (spec #139)`},
+		{`[\1-\3]`, "3", true, `escaped range \1-\3 matches 3 (spec #140)`},
+		{`[\1-\3]`, "4", false, `escaped range \1-\3 excludes 4 (spec #141)`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"__"+tt.path, func(t *testing.T) {
+			got := globMatch(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "%s: globMatch(%q, %q)", tt.note, tt.pattern, tt.path)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// EC-22: Negative pattern rejection in .gitattributes
+// Verified against git check-attr.
+// ---------------------------------------------------------------------------
+
+func TestEdgeNegativePatternRejection(t *testing.T) {
+	t.Run("negative_pattern_rejected", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("!foo test=bar\n"))
+		require.NoError(t, err)
+		assert.Len(t, ga.rules, 0, "!foo pattern should be rejected")
+	})
+
+	t.Run("escaped_bang_not_rejected", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("\\!foo test=bar\n"))
+		require.NoError(t, err)
+		assert.Len(t, ga.rules, 1, "\\!foo should not be rejected")
+		assert.Equal(t, "\\!foo", ga.rules[0].pattern)
+	})
+
+	t.Run("negative_pattern_does_not_affect_other_rules", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("!foo test=bar\n*.go linguist-language=Go\n"))
+		require.NoError(t, err)
+		assert.Len(t, ga.rules, 1, "only the non-negative rule should be kept")
+		lang, ok := ga.GetLanguage("main.go")
+		assert.True(t, ok)
+		assert.Equal(t, "Go", lang)
+	})
+}

--- a/gitattributes_test.go
+++ b/gitattributes_test.go
@@ -153,10 +153,11 @@ func TestMatchGitPattern(t *testing.T) {
 		{"vendor/*.go", "vendor/foo.go", true},
 		{"vendor/*.go", "src/vendor/foo.go", false},
 
-		// Trailing slash (directory pattern) - matches directory and files inside
+		// Trailing slash (directory-only pattern) - only matches directory paths
+		// Unlike .gitignore, .gitattributes trailing "/" does NOT recurse into files
 		{"vendor/", "vendor/", true},
-		{"vendor/", "vendor/foo.go", true},
-		{"vendor/", "vendor/lib/bar.go", true},
+		{"vendor/", "vendor/foo.go", false},
+		{"vendor/", "vendor/lib/bar.go", false},
 		{"vendor/", "vendor", false},
 		{"vendor/", "notvendor/foo.go", false},
 

--- a/gitattributes_test.go
+++ b/gitattributes_test.go
@@ -7,6 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func requireGitAttributeValue(t *testing.T, attrs map[string]gitAttributeValue, name string, want gitAttributeValue) {
+	t.Helper()
+	got, ok := attrs[name]
+	require.True(t, ok, "expected attribute %q to be present", name)
+	assert.Equal(t, want, got)
+}
+
 func TestParseGitAttributes(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -42,9 +49,71 @@ func TestParseGitAttributesValues(t *testing.T) {
 
 	rule := ga.rules[0]
 	assert.Equal(t, "*.go", rule.pattern)
-	assert.Equal(t, "true", rule.attrs["linguist-vendored"])
-	assert.Equal(t, "Go", rule.attrs["linguist-language"])
-	assert.Equal(t, "false", rule.attrs["linguist-documentation"])
+	requireGitAttributeValue(t, rule.attrs, "linguist-vendored", gitAttributeValue{kind: gitAttributeValueSet})
+	requireGitAttributeValue(t, rule.attrs, "linguist-language", gitAttributeValue{kind: gitAttributeValueString, value: "Go"})
+	requireGitAttributeValue(t, rule.attrs, "linguist-documentation", gitAttributeValue{kind: gitAttributeValueUnset})
+}
+
+func TestParseGitAttributesMacros(t *testing.T) {
+	t.Run("macro_expands_linguist_attrs", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("[attr]vendored linguist-vendored\n*.go vendored\n"))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 1)
+		requireGitAttributeValue(t, ga.rules[0].attrs, "linguist-vendored", gitAttributeValue{kind: gitAttributeValueSet})
+		assert.True(t, ga.IsVendor("main.go"))
+	})
+
+	t.Run("macro_can_be_defined_after_use", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("*.go vendored\n[attr]vendored linguist-vendored\n"))
+		require.NoError(t, err)
+		assert.True(t, ga.IsVendor("main.go"))
+	})
+
+	t.Run("nested_macros_expand_recursively", func(t *testing.T) {
+		content := "[attr]base linguist-vendored\n[attr]combo base linguist-language=Go\n*.go combo\n"
+		ga, err := ParseGitAttributes([]byte(content))
+		require.NoError(t, err)
+		assert.True(t, ga.IsVendor("main.go"))
+		lang, ok := ga.GetLanguage("main.go")
+		assert.True(t, ok)
+		assert.Equal(t, "Go", lang)
+	})
+
+	t.Run("special_macro_forms_do_not_expand", func(t *testing.T) {
+		content := "[attr]lang linguist-language=Go\n*.rb !lang\n*.py -lang\n*.ts lang=value\n"
+		ga, err := ParseGitAttributes([]byte(content))
+		require.NoError(t, err)
+		require.Len(t, ga.rules, 3)
+
+		_, hasLang := ga.rules[0].attrs["linguist-language"]
+		assert.False(t, hasLang)
+		_, hasLang = ga.rules[1].attrs["linguist-language"]
+		assert.False(t, hasLang)
+		_, hasLang = ga.rules[2].attrs["linguist-language"]
+		assert.False(t, hasLang)
+
+		_, ok := ga.GetLanguage("main.rb")
+		assert.False(t, ok)
+		_, ok = ga.GetLanguage("main.py")
+		assert.False(t, ok)
+		_, ok = ga.GetLanguage("main.ts")
+		assert.False(t, ok)
+	})
+
+	t.Run("macro_override_affects_has_potential_override", func(t *testing.T) {
+		ga, err := ParseGitAttributes([]byte("[attr]clear !linguist-vendored\nvendor/** clear\n"))
+		require.NoError(t, err)
+		assert.True(t, ga.HasPotentialOverride("linguist-vendored"))
+	})
+}
+
+func TestGitAttributesUnspecifiedVsStringValue(t *testing.T) {
+	content := "[attr]clear !linguist-vendored\nclear.go clear\nstring.go linguist-vendored=unspecified\n"
+	ga, err := ParseGitAttributes([]byte(content))
+	require.NoError(t, err)
+
+	assert.False(t, ga.IsVendor("clear.go"), "unspecified should fall back to default detection")
+	assert.True(t, ga.IsVendor("string.go"), "string value 'unspecified' should not be treated as reset")
 }
 
 func TestMatchGitPattern(t *testing.T) {

--- a/gitattributes_test.go
+++ b/gitattributes_test.go
@@ -146,8 +146,12 @@ func TestGitAttributesIsDetectable(t *testing.T) {
 	ga, err := ParseGitAttributes([]byte("*.sql linguist-detectable\n"))
 	require.NoError(t, err)
 
-	assert.True(t, ga.IsDetectable("schema.sql"))
-	assert.False(t, ga.IsDetectable("main.go"))
+	val, ok := ga.IsDetectable("schema.sql")
+	assert.True(t, ok, "should have override")
+	assert.True(t, val, "should be detectable")
+
+	_, ok = ga.IsDetectable("main.go")
+	assert.False(t, ok, "no override for main.go")
 }
 
 func TestGitAttributesGetLanguage(t *testing.T) {

--- a/gitattributes_test.go
+++ b/gitattributes_test.go
@@ -84,10 +84,12 @@ func TestMatchGitPattern(t *testing.T) {
 		{"vendor/*.go", "vendor/foo.go", true},
 		{"vendor/*.go", "src/vendor/foo.go", false},
 
-		// Trailing slash (directory only) - matches directory paths ending with "/"
+		// Trailing slash (directory pattern) - matches directory and files inside
 		{"vendor/", "vendor/", true},
+		{"vendor/", "vendor/foo.go", true},
+		{"vendor/", "vendor/lib/bar.go", true},
 		{"vendor/", "vendor", false},
-		{"vendor/", "vendor/foo.go", false},
+		{"vendor/", "notvendor/foo.go", false},
 
 		// Character classes
 		{"*.[ch]", "foo.c", true},

--- a/gitattributes_test.go
+++ b/gitattributes_test.go
@@ -1,0 +1,225 @@
+package enry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGitAttributes(t *testing.T) {
+	tests := []struct {
+		name      string
+		content   string
+		wantRules int
+	}{
+		{"empty", "", 0},
+		{"comment only", "# this is a comment\n", 0},
+		{"blank lines", "\n\n\n", 0},
+		{"pattern without attrs", "*.go\n", 0},
+		{"single attr set", "*.go linguist-language=Go\n", 1},
+		{"single attr unset", "*.go -linguist-vendored\n", 1},
+		{"single attr bare", "*.go linguist-vendored\n", 1},
+		{"multiple attrs", "*.go linguist-vendored linguist-language=Go\n", 1},
+		{"multiple rules", "*.go linguist-language=Go\n*.rb linguist-language=Ruby\n", 2},
+		{"mixed with comments", "# header\n*.go linguist-language=Go\n# footer\n", 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ga := ParseGitAttributes([]byte(tt.content))
+			assert.Equal(t, tt.wantRules, len(ga.rules))
+		})
+	}
+}
+
+func TestParseGitAttributesValues(t *testing.T) {
+	content := "*.go linguist-vendored linguist-language=Go -linguist-documentation\n"
+	ga := ParseGitAttributes([]byte(content))
+	require.Len(t, ga.rules, 1)
+
+	rule := ga.rules[0]
+	assert.Equal(t, "*.go", rule.pattern)
+	assert.Equal(t, "true", rule.attrs["linguist-vendored"])
+	assert.Equal(t, "Go", rule.attrs["linguist-language"])
+	assert.Equal(t, "false", rule.attrs["linguist-documentation"])
+}
+
+func TestMatchGitPattern(t *testing.T) {
+	tests := []struct {
+		pattern string
+		path    string
+		want    bool
+	}{
+		// Basic extension matching
+		{"*.go", "main.go", true},
+		{"*.go", "src/main.go", true},
+		{"*.go", "main.rb", false},
+
+		// Question mark
+		{"?.go", "a.go", true},
+		{"?.go", "ab.go", false},
+		{"?.go", "/.go", false},
+
+		// Double star
+		{"**/vendor/**", "a/vendor/b", true},
+		{"**/vendor/**", "vendor/b", true},
+		{"**/test", "a/b/test", true},
+		{"**/*.go", "src/main.go", true},
+		{"**/*.go", "main.go", true},
+
+		// Anchored patterns (leading /)
+		{"/vendor/**", "vendor/lib/foo.go", true},
+		{"/vendor/**", "src/vendor/foo.go", false},
+		{"/Makefile", "Makefile", true},
+		{"/Makefile", "src/Makefile", false},
+
+		// Basename matching (no slash in pattern, not anchored)
+		{"Makefile", "Makefile", true},
+		{"Makefile", "src/Makefile", true},
+
+		// Slash in pattern (not anchored) - matches full path
+		{"vendor/*.go", "vendor/foo.go", true},
+		{"vendor/*.go", "src/vendor/foo.go", false},
+
+		// Trailing slash (directory only) - should not match files
+		{"vendor/", "vendor", false},
+		{"vendor/", "vendor/foo.go", false},
+
+		// Character classes
+		{"*.[ch]", "foo.c", true},
+		{"*.[ch]", "foo.h", true},
+		{"*.[ch]", "foo.go", false},
+
+		// Star does not match slash
+		{"*.go", "a/b.go", true},   // basename match
+		{"*/*.go", "a/b.go", true}, // explicit slash in pattern
+		{"*/*.go", "b.go", false},  // needs a directory
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.pattern+"_"+tt.path, func(t *testing.T) {
+			got := matchGitPattern(tt.pattern, tt.path)
+			assert.Equal(t, tt.want, got, "matchGitPattern(%q, %q)", tt.pattern, tt.path)
+		})
+	}
+}
+
+func TestGitAttributesIsVendor(t *testing.T) {
+	ga := ParseGitAttributes([]byte("special/lib/* linguist-vendored\nmy/lib/* -linguist-vendored\n"))
+
+	// Explicit vendored
+	assert.True(t, ga.IsVendor("special/lib/foo.go"))
+
+	// Explicit not vendored
+	assert.False(t, ga.IsVendor("my/lib/bar.go"))
+
+	// No rule - falls back to default
+	assert.False(t, ga.IsVendor("src/main.go"))
+}
+
+func TestGitAttributesIsDocumentation(t *testing.T) {
+	ga := ParseGitAttributes([]byte("docs/* linguist-documentation\napi-docs/* -linguist-documentation\n"))
+
+	assert.True(t, ga.IsDocumentation("docs/guide.md"))
+	assert.False(t, ga.IsDocumentation("api-docs/spec.md"))
+}
+
+func TestGitAttributesIsGenerated(t *testing.T) {
+	ga := ParseGitAttributes([]byte("*.pb.go linguist-generated\nhand-written.pb.go -linguist-generated\n"))
+
+	assert.True(t, ga.IsGenerated("foo.pb.go", nil))
+
+	// Explicit override to not generated - last matching rule wins
+	assert.False(t, ga.IsGenerated("hand-written.pb.go", nil))
+}
+
+func TestGitAttributesIsDetectable(t *testing.T) {
+	ga := ParseGitAttributes([]byte("*.sql linguist-detectable\n"))
+
+	assert.True(t, ga.IsDetectable("schema.sql"))
+	assert.False(t, ga.IsDetectable("main.go"))
+}
+
+func TestGitAttributesGetLanguage(t *testing.T) {
+	ga := ParseGitAttributes([]byte("*.extension linguist-language=Go\n"))
+
+	lang, ok := ga.GetLanguage("foo.extension")
+	assert.True(t, ok)
+	assert.Equal(t, "Go", lang)
+
+	// No match
+	_, ok = ga.GetLanguage("foo.other")
+	assert.False(t, ok)
+}
+
+func TestGitAttributesGetLanguageAlias(t *testing.T) {
+	// "py" and "python" should both resolve to "Python"
+	ga := ParseGitAttributes([]byte("*.myext linguist-language=python\n"))
+
+	lang, ok := ga.GetLanguage("test.myext")
+	assert.True(t, ok)
+	assert.Equal(t, "Python", lang)
+}
+
+func TestGitAttributesMultipleRules(t *testing.T) {
+	// Last matching rule wins (git precedence)
+	content := `*.go linguist-language=Go
+special.go linguist-language=Ruby
+`
+	ga := ParseGitAttributes([]byte(content))
+
+	// "special.go" matches both rules; last one wins
+	lang, ok := ga.GetLanguage("special.go")
+	assert.True(t, ok)
+	assert.Equal(t, "Ruby", lang)
+
+	// "main.go" only matches first rule
+	lang, ok = ga.GetLanguage("main.go")
+	assert.True(t, ok)
+	assert.Equal(t, "Go", lang)
+}
+
+func TestGitAttributesMultipleAttrsPerLine(t *testing.T) {
+	content := "vendor/** linguist-vendored linguist-generated\n"
+	ga := ParseGitAttributes([]byte(content))
+
+	assert.True(t, ga.IsVendor("vendor/lib.go"))
+	assert.True(t, ga.IsGenerated("vendor/lib.go", nil))
+}
+
+func TestGitAttributesLinguistCompatibility(t *testing.T) {
+	// Test patterns that match real linguist .gitattributes usage
+	content := `
+# Mark vendored dependencies
+vendor/** linguist-vendored
+third_party/** linguist-vendored
+
+# Mark generated files
+*.pb.go linguist-generated
+*_generated.go linguist-generated
+
+# Override language detection
+Vagrantfile linguist-language=Ruby
+*.podspec linguist-language=Ruby
+Dockerfile.* linguist-language=Dockerfile
+
+# Documentation
+docs/** linguist-documentation
+`
+	ga := ParseGitAttributes([]byte(content))
+
+	assert.True(t, ga.IsVendor("vendor/github.com/pkg/errors/errors.go"))
+	assert.True(t, ga.IsVendor("third_party/protobuf/something.cc"))
+	assert.True(t, ga.IsGenerated("api/service.pb.go", nil))
+	assert.True(t, ga.IsGenerated("internal/types_generated.go", nil))
+	assert.True(t, ga.IsDocumentation("docs/getting-started.md"))
+
+	lang, ok := ga.GetLanguage("Vagrantfile")
+	assert.True(t, ok)
+	assert.Equal(t, "Ruby", lang)
+
+	lang, ok = ga.GetLanguage("MyApp.podspec")
+	assert.True(t, ok)
+	assert.Equal(t, "Ruby", lang)
+}

--- a/gitattributes_test.go
+++ b/gitattributes_test.go
@@ -27,7 +27,8 @@ func TestParseGitAttributes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ga := ParseGitAttributes([]byte(tt.content))
+			ga, err := ParseGitAttributes([]byte(tt.content))
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantRules, len(ga.rules))
 		})
 	}
@@ -35,7 +36,8 @@ func TestParseGitAttributes(t *testing.T) {
 
 func TestParseGitAttributesValues(t *testing.T) {
 	content := "*.go linguist-vendored linguist-language=Go -linguist-documentation\n"
-	ga := ParseGitAttributes([]byte(content))
+	ga, err := ParseGitAttributes([]byte(content))
+	require.NoError(t, err)
 	require.Len(t, ga.rules, 1)
 
 	rule := ga.rules[0]
@@ -82,7 +84,8 @@ func TestMatchGitPattern(t *testing.T) {
 		{"vendor/*.go", "vendor/foo.go", true},
 		{"vendor/*.go", "src/vendor/foo.go", false},
 
-		// Trailing slash (directory only) - should not match files
+		// Trailing slash (directory only) - matches directory paths ending with "/"
+		{"vendor/", "vendor/", true},
 		{"vendor/", "vendor", false},
 		{"vendor/", "vendor/foo.go", false},
 
@@ -106,7 +109,8 @@ func TestMatchGitPattern(t *testing.T) {
 }
 
 func TestGitAttributesIsVendor(t *testing.T) {
-	ga := ParseGitAttributes([]byte("special/lib/* linguist-vendored\nmy/lib/* -linguist-vendored\n"))
+	ga, err := ParseGitAttributes([]byte("special/lib/* linguist-vendored\nmy/lib/* -linguist-vendored\n"))
+	require.NoError(t, err)
 
 	// Explicit vendored
 	assert.True(t, ga.IsVendor("special/lib/foo.go"))
@@ -119,14 +123,16 @@ func TestGitAttributesIsVendor(t *testing.T) {
 }
 
 func TestGitAttributesIsDocumentation(t *testing.T) {
-	ga := ParseGitAttributes([]byte("docs/* linguist-documentation\napi-docs/* -linguist-documentation\n"))
+	ga, err := ParseGitAttributes([]byte("docs/* linguist-documentation\napi-docs/* -linguist-documentation\n"))
+	require.NoError(t, err)
 
 	assert.True(t, ga.IsDocumentation("docs/guide.md"))
 	assert.False(t, ga.IsDocumentation("api-docs/spec.md"))
 }
 
 func TestGitAttributesIsGenerated(t *testing.T) {
-	ga := ParseGitAttributes([]byte("*.pb.go linguist-generated\nhand-written.pb.go -linguist-generated\n"))
+	ga, err := ParseGitAttributes([]byte("*.pb.go linguist-generated\nhand-written.pb.go -linguist-generated\n"))
+	require.NoError(t, err)
 
 	assert.True(t, ga.IsGenerated("foo.pb.go", nil))
 
@@ -135,14 +141,16 @@ func TestGitAttributesIsGenerated(t *testing.T) {
 }
 
 func TestGitAttributesIsDetectable(t *testing.T) {
-	ga := ParseGitAttributes([]byte("*.sql linguist-detectable\n"))
+	ga, err := ParseGitAttributes([]byte("*.sql linguist-detectable\n"))
+	require.NoError(t, err)
 
 	assert.True(t, ga.IsDetectable("schema.sql"))
 	assert.False(t, ga.IsDetectable("main.go"))
 }
 
 func TestGitAttributesGetLanguage(t *testing.T) {
-	ga := ParseGitAttributes([]byte("*.extension linguist-language=Go\n"))
+	ga, err := ParseGitAttributes([]byte("*.extension linguist-language=Go\n"))
+	require.NoError(t, err)
 
 	lang, ok := ga.GetLanguage("foo.extension")
 	assert.True(t, ok)
@@ -155,7 +163,8 @@ func TestGitAttributesGetLanguage(t *testing.T) {
 
 func TestGitAttributesGetLanguageAlias(t *testing.T) {
 	// "py" and "python" should both resolve to "Python"
-	ga := ParseGitAttributes([]byte("*.myext linguist-language=python\n"))
+	ga, err := ParseGitAttributes([]byte("*.myext linguist-language=python\n"))
+	require.NoError(t, err)
 
 	lang, ok := ga.GetLanguage("test.myext")
 	assert.True(t, ok)
@@ -167,7 +176,8 @@ func TestGitAttributesMultipleRules(t *testing.T) {
 	content := `*.go linguist-language=Go
 special.go linguist-language=Ruby
 `
-	ga := ParseGitAttributes([]byte(content))
+	ga, err := ParseGitAttributes([]byte(content))
+	require.NoError(t, err)
 
 	// "special.go" matches both rules; last one wins
 	lang, ok := ga.GetLanguage("special.go")
@@ -182,7 +192,8 @@ special.go linguist-language=Ruby
 
 func TestGitAttributesMultipleAttrsPerLine(t *testing.T) {
 	content := "vendor/** linguist-vendored linguist-generated\n"
-	ga := ParseGitAttributes([]byte(content))
+	ga, err := ParseGitAttributes([]byte(content))
+	require.NoError(t, err)
 
 	assert.True(t, ga.IsVendor("vendor/lib.go"))
 	assert.True(t, ga.IsGenerated("vendor/lib.go", nil))
@@ -207,7 +218,8 @@ Dockerfile.* linguist-language=Dockerfile
 # Documentation
 docs/** linguist-documentation
 `
-	ga := ParseGitAttributes([]byte(content))
+	ga, err := ParseGitAttributes([]byte(content))
+	require.NoError(t, err)
 
 	assert.True(t, ga.IsVendor("vendor/github.com/pkg/errors/errors.go"))
 	assert.True(t, ga.IsVendor("third_party/protobuf/something.cc"))

--- a/plans/gitignore-gitattributes-spec.md
+++ b/plans/gitignore-gitattributes-spec.md
@@ -1,0 +1,1092 @@
+# Gitignore & Gitattributes Pattern Matching Specification
+
+> Extracted from Git source (commit cd412a4962). Intended as a self-contained reference
+> for implementing `.gitignore` and `.gitattributes` pattern matching in Go.
+> All concepts are explained inline — no Git internals knowledge required.
+>
+> Source files: [`wildmatch.c`](https://github.com/git/git/blob/master/wildmatch.c), [`wildmatch.h`](https://github.com/git/git/blob/master/wildmatch.h), [`dir.c`](https://github.com/git/git/blob/master/dir.c), [`dir.h`](https://github.com/git/git/blob/master/dir.h), [`attr.c`](https://github.com/git/git/blob/master/attr.c), [`attr.h`](https://github.com/git/git/blob/master/attr.h),
+> [`t/t3070-wildmatch.sh`](https://github.com/git/git/blob/master/t/t3070-wildmatch.sh), [`t/t0008-ignores.sh`](https://github.com/git/git/blob/master/t/t0008-ignores.sh), [`t/t3001-ls-files-others-exclude.sh`](https://github.com/git/git/blob/master/t/t3001-ls-files-others-exclude.sh), [`t/t0003-attributes.sh`](https://github.com/git/git/blob/master/t/t0003-attributes.sh),
+> [`Documentation/gitignore.adoc`](https://github.com/git/git/blob/master/Documentation/gitignore.adoc), [`Documentation/gitattributes.adoc`](https://github.com/git/git/blob/master/Documentation/gitattributes.adoc)
+
+---
+
+## Part 1: Wildmatch — The Pattern Matching Engine
+
+### 1.1 What Is Wildmatch?
+
+Wildmatch is Git's glob-style pattern matching function. It takes a **pattern** and a **text**
+string and returns whether the pattern matches the text. It is the engine behind all
+`.gitignore` pattern matching, ref filtering, pathspec matching, etc.
+
+```
+func wildmatch(pattern, text string, flags uint) bool
+```
+
+### 1.2 Matching Modes
+
+Wildmatch has two independent boolean flags that combine into 4 modes:
+
+| Flag | Name | Effect |
+|------|------|--------|
+| `WM_PATHNAME` | **Pathname mode** | The `/` character is treated as a special directory separator. `*`, `?`, and `[…]` **cannot match** `/`. Only `**` can cross `/` boundaries. |
+| `WM_CASEFOLD` | **Case-insensitive** | Matching is case-insensitive. `A` matches `a`. Character ranges like `[A-Z]` also match lowercase. POSIX classes like `[:upper:]` match lowercase too. |
+
+The 4 combinations:
+
+| Column abbrev | Flags | Used by |
+|---------------|-------|---------|
+| **PN** | `WM_PATHNAME` | `.gitignore` matching against full relative paths |
+| **PN+CF** | `WM_PATHNAME \| WM_CASEFOLD` | `.gitignore` on case-insensitive filesystems |
+| **PM** | *(none)* | `.gitignore` matching against basenames only (no `/` in pattern) |
+| **PM+CF** | `WM_CASEFOLD` | basename matching, case-insensitive |
+
+**For `.gitignore`**: patterns containing `/` are matched with `WM_PATHNAME` against the full
+relative path. Patterns without `/` are matched with no flags against the basename only.
+Case-insensitive mode (`WM_CASEFOLD`) is added when the filesystem is case-insensitive
+(e.g., macOS HFS+, Windows NTFS).
+
+### 1.3 Pattern Syntax
+
+| Syntax | Meaning |
+|--------|---------|
+| `*` | Matches any sequence of characters **except** `/` (in pathname mode). Without pathname mode, matches anything. |
+| `**` | In pathname mode and when at a path boundary (start of pattern, after `/`, or before `/`/end): matches any sequence including `/` — i.e., zero or more directory levels. Otherwise treated as `*`. |
+| `?` | Matches exactly one character **except** `/` (in pathname mode). Without pathname mode, matches any character. |
+| `[abc]` | Character class — matches one of the listed characters. |
+| `[a-z]` | Character range — matches one character in the range (inclusive). |
+| `[!abc]` or `[^abc]` | Negated character class — matches one character NOT in the set. In pathname mode, `[…]` never matches `/` regardless of contents. |
+| `[[:alpha:]]` | POSIX character class. Supported: `alnum`, `alpha`, `blank`, `cntrl`, `digit`, `graph`, `lower`, `print`, `punct`, `space`, `upper`, `xdigit`. |
+| `\x` | Escape — the next character is matched literally (e.g., `\*` matches a literal `*`, `\\` matches `\`, `\a` matches `a`). |
+
+**`**` boundary rules** (pathname mode only):
+- `**/foo` — `**` at start followed by `/`: matches `foo` at any depth
+- `foo/**` — `**` at end preceded by `/`: matches everything inside `foo/`
+- `foo/**/bar` — `/**/` in middle: matches `foo/bar`, `foo/x/bar`, `foo/x/y/bar`, etc. (zero or more directories)
+- `foo**bar` — `**` NOT at a boundary: treated as regular `*` (cannot cross `/`)
+
+### 1.4 Return Values
+
+- **1** (match): pattern matches the text
+- **0** (no match): pattern does not match
+
+Internally, the algorithm uses abort codes to prevent exponential backtracking, but these
+are not exposed to callers.
+
+---
+
+### 1.5 Test Cases — Basic Features
+
+These test cases exercise literals, `?`, `*`, `\` escaping, and character classes.
+
+In all tables: **1** = match, **0** = no match.
+
+| # | Text | Pattern | PN | PN+CF | PM | PM+CF | Note |
+|---|------|---------|:--:|:-----:|:--:|:-----:|------|
+| 1 | `foo` | `foo` | 1 | 1 | 1 | 1 | Exact literal match |
+| 2 | `foo` | `bar` | 0 | 0 | 0 | 0 | Different literal |
+| 3 | *(empty)* | *(empty)* | 1 | 1 | 1 | 1 | Both empty strings match |
+| 4 | `foo` | `???` | 1 | 1 | 1 | 1 | Three `?` match three chars |
+| 5 | `foo` | `??` | 0 | 0 | 0 | 0 | Two `?` don't match three chars |
+| 6 | `foo` | `*` | 1 | 1 | 1 | 1 | `*` matches everything |
+| 7 | `foo` | `f*` | 1 | 1 | 1 | 1 | `f*` matches `foo` |
+| 8 | `foo` | `*f` | 0 | 0 | 0 | 0 | `*f` — `foo` doesn't end with `f` |
+| 9 | `foo` | `*foo*` | 1 | 1 | 1 | 1 | `*foo*` matches |
+| 10 | `foobar` | `*ob*a*r*` | 1 | 1 | 1 | 1 | Multiple `*` segments |
+| 11 | `aaaaaaabababab` | `*ab` | 1 | 1 | 1 | 1 | Repetitive text, ends with `ab` |
+| 12 | `foo*` | `foo\*` | 1 | 1 | 1 | 1 | `\*` matches literal `*` in text |
+| 13 | `foobar` | `foo\*bar` | 0 | 0 | 0 | 0 | `\*` requires literal `*` between foo and bar |
+| 14 | `f\oo` | `f\\oo` | 1 | 1 | 1 | 1 | `\\` matches literal `\` |
+| 15 | `foo\` | `foo\` | 0 | 0 | 0 | 0 | Trailing `\` in pattern is invalid — no match |
+| 16 | `ball` | `*[al]?` | 1 | 1 | 1 | 1 | `*` then char class then `?` |
+| 17 | `ten` | `[ten]` | 0 | 0 | 0 | 0 | `[ten]` matches ONE char, not three |
+| 18 | `ten` | `**[!te]` | 1 | 1 | 1 | 1 | `**` matches `te`, `[!te]` matches `n` |
+| 19 | `ten` | `**[!ten]` | 0 | 0 | 0 | 0 | All chars of `ten` are in `[ten]` |
+| 20 | `ten` | `t[a-g]n` | 1 | 1 | 1 | 1 | `e` is in range `a-g` |
+| 21 | `ten` | `t[!a-g]n` | 0 | 0 | 0 | 0 | `e` IS in `a-g`, negated → no match |
+| 22 | `ton` | `t[!a-g]n` | 1 | 1 | 1 | 1 | `o` is NOT in `a-g`, negated → match |
+| 23 | `ton` | `t[^a-g]n` | 1 | 1 | 1 | 1 | `^` is alias for `!` in character classes |
+| 24 | `a]b` | `a[]]b` | 1 | 1 | 1 | 1 | `]` immediately after `[` is literal |
+| 25 | `a-b` | `a[]-]b` | 1 | 1 | 1 | 1 | Class `[]-]` contains `]` and `-` |
+| 26 | `a]b` | `a[]-]b` | 1 | 1 | 1 | 1 | `]` matches `[]-]` |
+| 27 | `aab` | `a[]-]b` | 0 | 0 | 0 | 0 | `a` is not `]` or `-` |
+| 28 | `aab` | `a[]a-]b` | 1 | 1 | 1 | 1 | Class `[]a-]` contains `]`, `a`, `-` |
+| 29 | `]` | `]` | 1 | 1 | 1 | 1 | Literal `]` outside brackets |
+
+### 1.6 Test Cases — Slash / Pathname Matching
+
+These test the interaction between `*`, `**`, `?`, `[…]` and the `/` separator.
+The key insight: in **pathname mode** (PN), `/` is special and `*`/`?`/`[…]` cannot cross it.
+In **plain mode** (PM), `/` is an ordinary character.
+
+| # | Text | Pattern | PN | PN+CF | PM | PM+CF | Note |
+|---|------|---------|:--:|:-----:|:--:|:-----:|------|
+| 30 | `foo/baz/bar` | `foo*bar` | 0 | 0 | 1 | 1 | `*` can't cross `/` in PN |
+| 31 | `foo/baz/bar` | `foo**bar` | 0 | 0 | 1 | 1 | `**` not at boundary → treated as `*` in PN |
+| 32 | `foobazbar` | `foo**bar` | 1 | 1 | 1 | 1 | No `/` in text → `**` works like `*` |
+| 33 | `foo/baz/bar` | `foo/**/bar` | 1 | 1 | 1 | 1 | `/**/` matches one dir level |
+| 34 | `foo/baz/bar` | `foo/**/**/bar` | 1 | 1 | 0 | 0 | Multiple `/**/` works in PN; PM treats `**` literally |
+| 35 | `foo/b/a/z/bar` | `foo/**/bar` | 1 | 1 | 1 | 1 | `/**/` matches multiple dir levels |
+| 36 | `foo/b/a/z/bar` | `foo/**/**/bar` | 1 | 1 | 1 | 1 | Multiple `/**/` matches deep paths |
+| 37 | `foo/bar` | `foo/**/bar` | 1 | 1 | 0 | 0 | `/**/` matches **zero** dirs in PN |
+| 38 | `foo/bar` | `foo/**/**/bar` | 1 | 1 | 0 | 0 | Multiple `/**/` also matches zero dirs in PN |
+| 39 | `foo/bar` | `foo?bar` | 0 | 0 | 1 | 1 | `?` can't match `/` in PN |
+| 40 | `foo/bar` | `foo[/]bar` | 0 | 0 | 1 | 1 | `[/]` can't match `/` in PN |
+| 41 | `foo/bar` | `foo[^a-z]bar` | 0 | 0 | 1 | 1 | Negated class can't match `/` in PN |
+| 42 | `foo/bar` | `f[^eiu][^eiu][^eiu][^eiu][^eiu]r` | 0 | 0 | 1 | 1 | Multiple negated classes can't cross `/` in PN |
+| 43 | `foo-bar` | `f[^eiu][^eiu][^eiu][^eiu][^eiu]r` | 1 | 1 | 1 | 1 | No `/` in text → works fine |
+| 44 | `foo` | `**/foo` | 1 | 1 | 0 | 0 | `**/` at start matches at root in PN; PM: literal `**/` |
+| 45 | `XXX/foo` | `**/foo` | 1 | 1 | 1 | 1 | `**/foo` matches at any depth |
+| 46 | `bar/baz/foo` | `**/foo` | 1 | 1 | 1 | 1 | `**/foo` matches deep |
+| 47 | `bar/baz/foo` | `*/foo` | 0 | 0 | 1 | 1 | `*/foo` only matches one dir in PN |
+| 48 | `foo/bar/baz` | `**/bar*` | 0 | 0 | 1 | 1 | `**/bar*` — `**` at boundary but `bar*` can't match `bar/baz` in PN |
+| 49 | `deep/foo/bar/baz` | `**/bar/*` | 1 | 1 | 1 | 1 | `**/bar/*` matches |
+| 50 | `deep/foo/bar/baz/` | `**/bar/*` | 0 | 0 | 1 | 1 | Trailing `/` in text: `*` can't match `baz/` in PN |
+| 51 | `deep/foo/bar/baz/` | `**/bar/**` | 1 | 1 | 1 | 1 | `/**` at end matches trailing `/` |
+| 52 | `deep/foo/bar` | `**/bar/*` | 0 | 0 | 0 | 0 | Nothing after `bar/` for `*` to match |
+| 53 | `deep/foo/bar/` | `**/bar/**` | 1 | 1 | 1 | 1 | `/**` matches the trailing `/` |
+| 54 | `foo/bar/baz` | `**/bar**` | 0 | 0 | 1 | 1 | `bar**` — `**` not at boundary in PN |
+| 55 | `foo/bar/baz/x` | `*/bar/**` | 1 | 1 | 1 | 1 | `*/` matches one dir, `/**` matches rest |
+| 56 | `deep/foo/bar/baz/x` | `*/bar/**` | 0 | 0 | 1 | 1 | `*/` only matches one dir in PN |
+| 57 | `deep/foo/bar/baz/x` | `**/bar/*/*` | 1 | 1 | 1 | 1 | `**/bar` then `/*` twice |
+
+### 1.7 Test Cases — Various Additional
+
+| # | Text | Pattern | PN | PN+CF | PM | PM+CF | Note |
+|---|------|---------|:--:|:-----:|:--:|:-----:|------|
+| 58 | `acrt` | `a[c-c]st` | 0 | 0 | 0 | 0 | `[c-c]` is just `c`; `acrt` ≠ `acst` |
+| 59 | `acrt` | `a[c-c]rt` | 1 | 1 | 1 | 1 | `[c-c]` matches `c`, rest matches |
+| 60 | `]` | `[!]-]` | 0 | 0 | 0 | 0 | `]` IS in `]-]`, negated → no match |
+| 61 | `a` | `[!]-]` | 1 | 1 | 1 | 1 | `a` is NOT in `]-]`, negated → match |
+| 62 | *(empty)* | `\` | 0 | 0 | 0 | 0 | Lone `\` is invalid pattern |
+| 63 | `\` | `\` | 0 | 0 | 0 | 0 | Lone `\` pattern: invalid, never matches |
+| 64 | `XXX/\` | `*/\` | 0 | 0 | 0 | 0 | Trailing `\` in pattern is invalid |
+| 65 | `XXX/\` | `*/\\` | 1 | 1 | 1 | 1 | `\\` matches literal `\` |
+| 66 | `foo` | `foo` | 1 | 1 | 1 | 1 | Exact match (repeated for context) |
+| 67 | `@foo` | `@foo` | 1 | 1 | 1 | 1 | `@` has no special meaning |
+| 68 | `foo` | `@foo` | 0 | 0 | 0 | 0 | `@` is literal |
+| 69 | `[ab]` | `\[ab]` | 1 | 1 | 1 | 1 | `\[` matches literal `[` |
+| 70 | `[ab]` | `[[]ab]` | 1 | 1 | 1 | 1 | `[[]` is char class containing `[` |
+| 71 | `[ab]` | `[[:]ab]` | 1 | 1 | 1 | 1 | `[[:` without closing `:]` — treated as chars `[`, `:` |
+| 72 | `[ab]` | `[[::]ab]` | 0 | 0 | 0 | 0 | `[::]` is invalid POSIX class → abort |
+| 73 | `[ab]` | `[[:digit]ab]` | 1 | 1 | 1 | 1 | `[:digit]` missing final `:` → treated as chars |
+| 74 | `[ab]` | `[\[:]ab]` | 1 | 1 | 1 | 1 | `\[` in class is literal `[` |
+| 75 | `?a?b` | `\??\?b` | 1 | 1 | 1 | 1 | `\?` matches literal `?`, `?` matches `a` |
+| 76 | `abc` | `\a\b\c` | 1 | 1 | 1 | 1 | `\a` matches `a` (escape of non-special char) |
+| 77 | `foo` | *(empty)* | 0 | 0 | 0 | 0 | Empty pattern does not match non-empty text |
+| 78 | `foo/bar/baz/to` | `**/t[o]` | 1 | 1 | 1 | 1 | `**/` then char class `[o]` |
+
+### 1.8 Test Cases — POSIX Character Classes
+
+| # | Text | Pattern | PN | PN+CF | PM | PM+CF | Note |
+|---|------|---------|:--:|:-----:|:--:|:-----:|------|
+| 79 | `a1B` | `[[:alpha:]][[:digit:]][[:upper:]]` | 1 | 1 | 1 | 1 | `a`=alpha, `1`=digit, `B`=upper |
+| 80 | `a` | `[[:digit:][:upper:][:space:]]` | 0 | 1 | 0 | 1 | `a` is not digit/upper/space; with casefold, `[:upper:]` matches lowercase |
+| 81 | `A` | `[[:digit:][:upper:][:space:]]` | 1 | 1 | 1 | 1 | `A` is `[:upper:]` |
+| 82 | `1` | `[[:digit:][:upper:][:space:]]` | 1 | 1 | 1 | 1 | `1` is `[:digit:]` |
+| 83 | `1` | `[[:digit:][:upper:][:spaci:]]` | 0 | 0 | 0 | 0 | `[:spaci:]` is invalid → abort, no match |
+| 84 | ` ` | `[[:digit:][:upper:][:space:]]` | 1 | 1 | 1 | 1 | space is `[:space:]` |
+| 85 | `.` | `[[:digit:][:upper:][:space:]]` | 0 | 0 | 0 | 0 | `.` is none of those |
+| 86 | `.` | `[[:digit:][:punct:][:space:]]` | 1 | 1 | 1 | 1 | `.` is `[:punct:]` |
+| 87 | `5` | `[[:xdigit:]]` | 1 | 1 | 1 | 1 | `5` is hex digit |
+| 88 | `f` | `[[:xdigit:]]` | 1 | 1 | 1 | 1 | `f` is hex digit |
+| 89 | `D` | `[[:xdigit:]]` | 1 | 1 | 1 | 1 | `D` is hex digit |
+| 90 | `_` | `[[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:graph:][:lower:][:print:][:punct:][:space:][:upper:][:xdigit:]]` | 1 | 1 | 1 | 1 | `_` matches `[:punct:]` |
+| 91 | `.` | `[^[:alnum:][:alpha:][:blank:][:cntrl:][:digit:][:lower:][:space:][:upper:][:xdigit:]]` | 1 | 1 | 1 | 1 | `.` is not in any of those (but is `[:graph:]`/`[:print:]`/`[:punct:]`, which are excluded from the negated set) |
+| 92 | `5` | `[a-c[:digit:]x-z]` | 1 | 1 | 1 | 1 | `5` matches `[:digit:]` |
+| 93 | `b` | `[a-c[:digit:]x-z]` | 1 | 1 | 1 | 1 | `b` matches `a-c` |
+| 94 | `y` | `[a-c[:digit:]x-z]` | 1 | 1 | 1 | 1 | `y` matches `x-z` |
+| 95 | `q` | `[a-c[:digit:]x-z]` | 0 | 0 | 0 | 0 | `q` is not in any range/class |
+
+### 1.9 Test Cases — Malformed / Edge-Case Patterns
+
+These test bracket expressions with unusual or incomplete syntax.
+
+| # | Text | Pattern | PN | PN+CF | PM | PM+CF | Note |
+|---|------|---------|:--:|:-----:|:--:|:-----:|------|
+| 96 | `]` | `[\-^]` | 1 | 1 | 1 | 1 | `\-` is literal `-`; class is `-` and `^`; but `]` matches `^`? No — range `-` to `^` (ASCII 45-94) includes `]` (93) |
+| 97 | `[` | `[\-^]` | 0 | 0 | 0 | 0 | `[` is ASCII 91, within range `-`(45) to `^`(94)… but `\-` escapes `-` as literal, so class has escaped `-` then range check with `^`. Actually: `\-` is literal `-`, then `-^` is not a range because `-` was consumed by escape. So class is {`-`, `^`}. `[` matches neither. |
+| 98 | `-` | `[\-_]` | 1 | 1 | 1 | 1 | `\-` is literal `-`; then range `-` to `_`. `-` matches. |
+| 99 | `]` | `[\]]` | 1 | 1 | 1 | 1 | `\]` is literal `]` in class |
+| 100 | `\]` | `[\]]` | 0 | 0 | 0 | 0 | Class matches single char `]`, not `\]` |
+| 101 | `\` | `[\]]` | 0 | 0 | 0 | 0 | `\` is not `]` |
+| 102 | `ab` | `a[]b` | 0 | 0 | 0 | 0 | Empty bracket `[]` — never completes, no match |
+| 103 | `a[]b` | `a[]b` | 0 | 0 | 0 | 0 | Wildmatch: incomplete bracket → no match |
+| 104 | `ab[` | `ab[` | 0 | 0 | 0 | 0 | Wildmatch: incomplete bracket → no match |
+| 105 | `ab` | `[!` | 0 | 0 | 0 | 0 | Incomplete negated bracket |
+| 106 | `ab` | `[-` | 0 | 0 | 0 | 0 | Incomplete bracket with `-` |
+| 107 | `-` | `[-]` | 1 | 1 | 1 | 1 | `-` at start of class is literal |
+| 108 | `-` | `[a-` | 0 | 0 | 0 | 0 | Incomplete range |
+| 109 | `-` | `[!a-` | 0 | 0 | 0 | 0 | Incomplete negated range |
+| 110 | `-` | `[--A]` | 1 | 1 | 1 | 1 | Range `-` (45) to `A` (65); `-` is in range |
+| 111 | `5` | `[--A]` | 1 | 1 | 1 | 1 | `5` (53) is in range 45-65 |
+| 112 | ` ` | `[ --]` | 1 | 1 | 1 | 1 | Range ` ` (32) to `-` (45); space (32) is in range |
+| 113 | `$` | `[ --]` | 1 | 1 | 1 | 1 | `$` (36) is in range 32-45 |
+| 114 | `-` | `[ --]` | 1 | 1 | 1 | 1 | `-` (45) is in range 32-45 |
+| 115 | `0` | `[ --]` | 0 | 0 | 0 | 0 | `0` (48) is NOT in range 32-45 |
+| 116 | `-` | `[---]` | 1 | 1 | 1 | 1 | Range `-` to `-`; matches `-` |
+| 117 | `-` | `[------]` | 1 | 1 | 1 | 1 | Multiple `-` sequences; matches `-` |
+| 118 | `j` | `[a-e-n]` | 0 | 0 | 0 | 0 | Range `a-e` then literal `-` then `n`; `j` matches none |
+| 119 | `-` | `[a-e-n]` | 1 | 1 | 1 | 1 | `-` matches the literal `-` after the range |
+| 120 | `a` | `[!------]` | 1 | 1 | 1 | 1 | Negated class containing only `-`; `a` is not `-` |
+| 121 | `[` | `[]-a]` | 0 | 0 | 0 | 0 | Range `]` (93) to `a` (97); `[` (91) is not in range |
+| 122 | `^` | `[]-a]` | 1 | 1 | 1 | 1 | `^` (94) is in range 93-97 |
+| 123 | `^` | `[!]-a]` | 0 | 0 | 0 | 0 | Negated: `^` IS in range → no match |
+| 124 | `[` | `[!]-a]` | 1 | 1 | 1 | 1 | Negated: `[` is NOT in range → match |
+| 125 | `^` | `[a^bc]` | 1 | 1 | 1 | 1 | `^` as literal char in class (not at start) |
+| 126 | `-b]` | `[a-]b]` | 1 | 1 | 1 | 1 | `[a-]` is class with `a` and `-` (before `]`); then literal `b]` |
+| 127 | `\` | `[\]` | 0 | 0 | 0 | 0 | `\]` escapes `]`, bracket never closes → no match |
+| 128 | `\` | `[\\]` | 1 | 1 | 1 | 1 | `\\` in class is literal `\` |
+| 129 | `\` | `[!\\]` | 0 | 0 | 0 | 0 | Negated: `\` IS `\\` → no match |
+| 130 | `G` | `[A-\\]` | 1 | 1 | 1 | 1 | Range `A` (65) to `\` (92); `G` (71) is in range |
+| 131 | `aaabbb` | `b*a` | 0 | 0 | 0 | 0 | Text doesn't start with `b` |
+| 132 | `aabcaa` | `*ba*` | 0 | 0 | 0 | 0 | No `ba` substring in text |
+| 133 | `,` | `[,]` | 1 | 1 | 1 | 1 | Literal `,` in class |
+| 134 | `,` | `[\\,]` | 1 | 1 | 1 | 1 | Class: `\\` (literal `\`) and `,`; `,` matches |
+| 135 | `\` | `[\\,]` | 1 | 1 | 1 | 1 | `\` matches `\\` in class |
+| 136 | `-` | `[,-.]` | 1 | 1 | 1 | 1 | Range `,` (44) to `.` (46); `-` (45) is in range |
+| 137 | `+` | `[,-.]` | 0 | 0 | 0 | 0 | `+` (43) is NOT in range 44-46 |
+| 138 | `-.]` | `[,-.]` | 0 | 0 | 0 | 0 | Class matches single char, text is 3 chars |
+| 139 | `2` | `[\1-\3]` | 1 | 1 | 1 | 1 | `\1` to `\3` (escaped digits = literal `1`-`3`); `2` in range |
+| 140 | `3` | `[\1-\3]` | 1 | 1 | 1 | 1 | `3` in range |
+| 141 | `4` | `[\1-\3]` | 0 | 0 | 0 | 0 | `4` not in range `1`-`3` |
+| 142 | `\` | `[[-\]]` | 1 | 1 | 1 | 1 | Range `[` (91) to `\]` (escaped `]` = 93); `\` (92) in range |
+| 143 | `[` | `[[-\]]` | 1 | 1 | 1 | 1 | `[` (91) in range 91-93 |
+| 144 | `]` | `[[-\]]` | 1 | 1 | 1 | 1 | `]` (93) in range 91-93 |
+| 145 | `-` | `[[-\]]` | 0 | 0 | 0 | 0 | `-` (45) NOT in range 91-93 |
+
+### 1.10 Test Cases — Recursion / Complex Multi-Wildcard
+
+| # | Text | Pattern | PN | PN+CF | PM | PM+CF | Note |
+|---|------|---------|:--:|:-----:|:--:|:-----:|------|
+| 146 | `-adobe-courier-bold-o-normal--12-120-75-75-m-70-iso8859-1` | `-*-*-*-*-*-*-12-*-*-*-m-*-*-*` | 1 | 1 | 1 | 1 | Complex multi-`*` pattern |
+| 147 | `-adobe-courier-bold-o-normal--12-120-75-75-X-70-iso8859-1` | `-*-*-*-*-*-*-12-*-*-*-m-*-*-*` | 0 | 0 | 0 | 0 | `X` where `m` is expected |
+| 148 | `-adobe-courier-bold-o-normal--12-120-75-75-/-70-iso8859-1` | `-*-*-*-*-*-*-12-*-*-*-m-*-*-*` | 0 | 0 | 0 | 0 | `/` in text; even in PM, `m` is required not `/` |
+| 149 | `XXX/adobe/courier/bold/o/normal//12/120/75/75/m/70/iso8859/1` | `XXX/*/*/*/*/*/*/12/*/*/*/m/*/*/*` | 1 | 1 | 1 | 1 | Path with `//` (empty segment) |
+| 150 | `XXX/adobe/courier/bold/o/normal//12/120/75/75/X/70/iso8859/1` | `XXX/*/*/*/*/*/*/12/*/*/*/m/*/*/*` | 0 | 0 | 0 | 0 | `X` where `m` expected |
+| 151 | `abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txt` | `**/*a*b*g*n*t` | 1 | 1 | 1 | 1 | Deep path, complex suffix |
+| 152 | `abcd/abcdefg/abcdefghijk/abcdefghijklmnop.txtz` | `**/*a*b*g*n*t` | 0 | 0 | 0 | 0 | `txtz` doesn't end with `t` |
+| 153 | `foo` | `*/*/*` | 0 | 0 | 0 | 0 | 0 slashes, need 2 |
+| 154 | `foo/bar` | `*/*/*` | 0 | 0 | 0 | 0 | 1 slash, need 2 |
+| 155 | `foo/bba/arr` | `*/*/*` | 1 | 1 | 1 | 1 | Exactly 2 slashes → 3 segments |
+| 156 | `foo/bb/aa/rr` | `*/*/*` | 0 | 0 | 1 | 1 | 3 slashes: PN `*` can't cross `/`; PM can |
+| 157 | `foo/bb/aa/rr` | `**/**/**` | 1 | 1 | 1 | 1 | `**` crosses all `/` boundaries |
+| 158 | `abcXdefXghi` | `*X*i` | 1 | 1 | 1 | 1 | No `/` → all modes agree |
+| 159 | `ab/cXd/efXg/hi` | `*X*i` | 0 | 0 | 1 | 1 | PN: `*` can't cross `/` |
+| 160 | `ab/cXd/efXg/hi` | `*/*X*/*/*i` | 1 | 1 | 1 | 1 | Explicit `/` in pattern matches structure |
+| 161 | `ab/cXd/efXg/hi` | `**/*X*/**/*i` | 1 | 1 | 1 | 1 | `**` and `*` work together |
+
+### 1.11 Test Cases — Extra Pathmatch
+
+| # | Text | Pattern | PN | PN+CF | PM | PM+CF | Note |
+|---|------|---------|:--:|:-----:|:--:|:-----:|------|
+| 162 | `foo` | `fo` | 0 | 0 | 0 | 0 | Incomplete pattern |
+| 163 | `foo/bar` | `foo/bar` | 1 | 1 | 1 | 1 | Exact path |
+| 164 | `foo/bar` | `foo/*` | 1 | 1 | 1 | 1 | `*` matches `bar` |
+| 165 | `foo/bba/arr` | `foo/*` | 0 | 0 | 1 | 1 | PN: `*` can't match `bba/arr` |
+| 166 | `foo/bba/arr` | `foo/**` | 1 | 1 | 1 | 1 | `/**` matches everything below |
+| 167 | `foo/bba/arr` | `foo*` | 0 | 0 | 1 | 1 | PN: `*` after `foo` can't cross `/` |
+| 168 | `foo/bba/arr` | `foo**` | 0 | 0 | 1 | 1 | PN: `**` not at boundary (no preceding `/`) → treated as `*` |
+| 169 | `foo/bba/arr` | `foo/*arr` | 0 | 0 | 1 | 1 | PN: `*` matches only within one dir |
+| 170 | `foo/bba/arr` | `foo/**arr` | 0 | 0 | 1 | 1 | PN: `**` before `arr` not at boundary → like `*` |
+| 171 | `foo/bba/arr` | `foo/*z` | 0 | 0 | 0 | 0 | No `z` anywhere |
+| 172 | `foo/bba/arr` | `foo/**z` | 0 | 0 | 0 | 0 | No `z` anywhere |
+| 173 | `foo/bar` | `foo?bar` | 0 | 0 | 1 | 1 | PN: `?` can't match `/` |
+| 174 | `foo/bar` | `foo[/]bar` | 0 | 0 | 1 | 1 | PN: `[/]` can't match `/` |
+| 175 | `foo/bar` | `foo[^a-z]bar` | 0 | 0 | 1 | 1 | PN: negated class can't match `/` |
+| 176 | `ab/cXd/efXg/hi` | `*Xg*i` | 0 | 0 | 1 | 1 | PN: `*` can't cross multiple `/` |
+
+### 1.12 Test Cases — Case Sensitivity
+
+These show how `WM_CASEFOLD` affects character ranges and POSIX classes.
+
+| # | Text | Pattern | PN | PN+CF | PM | PM+CF | Note |
+|---|------|---------|:--:|:-----:|:--:|:-----:|------|
+| 177 | `a` | `[A-Z]` | 0 | 1 | 0 | 1 | `a` not in `A-Z`; casefold: `A` in `A-Z` |
+| 178 | `A` | `[A-Z]` | 1 | 1 | 1 | 1 | `A` in `A-Z` |
+| 179 | `A` | `[a-z]` | 0 | 1 | 0 | 1 | `A` not in `a-z`; casefold: `a` in `a-z` |
+| 180 | `a` | `[a-z]` | 1 | 1 | 1 | 1 | `a` in `a-z` |
+| 181 | `a` | `[[:upper:]]` | 0 | 1 | 0 | 1 | `a` is not upper; casefold: `[:upper:]` matches lowercase too |
+| 182 | `A` | `[[:upper:]]` | 1 | 1 | 1 | 1 | `A` is upper |
+| 183 | `A` | `[[:lower:]]` | 0 | 1 | 0 | 1 | `A` is not lower; casefold matches |
+| 184 | `a` | `[[:lower:]]` | 1 | 1 | 1 | 1 | `a` is lower |
+| 185 | `A` | `[B-Za]` | 0 | 1 | 0 | 1 | `A` not in `B-Z` or `a`; casefold: `a` matches literal `a` in class |
+| 186 | `a` | `[B-Za]` | 1 | 1 | 1 | 1 | `a` matches literal `a` in class |
+| 187 | `A` | `[B-a]` | 0 | 1 | 0 | 1 | Range `B`(66) to `a`(97); `A`(65) not in range; casefold matches |
+| 188 | `a` | `[B-a]` | 1 | 1 | 1 | 1 | `a`(97) is in range 66-97 |
+| 189 | `z` | `[Z-y]` | 0 | 1 | 0 | 1 | Range `Z`(90) to `y`(121); `z`(122) not in range; casefold: `Z`(90) is in range |
+| 190 | `Z` | `[Z-y]` | 1 | 1 | 1 | 1 | `Z`(90) is in range 90-121 |
+
+### 1.13 Test Case — Exponential Backtracking Prevention
+
+This test ensures the matching engine does **not** exhibit exponential time complexity
+on pathological patterns. An implementation must complete (or abort) in bounded time.
+
+| Text | Pattern | Expected |
+|------|---------|----------|
+| `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab` (59 `a`s + `b`) | `*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a*a` (16 `*a` segments) | **No match**, must complete in < 2 seconds |
+
+A naive recursive implementation would try O(2^n) paths. The correct implementation
+uses abort codes to prune the search space.
+
+---
+
+## Part 2: Gitignore Pattern Parsing
+
+This section describes how lines in a `.gitignore` file are parsed into match rules.
+
+### 2.1 File Format
+
+A `.gitignore` file is a plain text file with one pattern per line. The parser processes it
+line by line with these rules (applied in order):
+
+1. **UTF-8 BOM**: If the file starts with a UTF-8 BOM (`\xEF\xBB\xBF`), skip it.
+2. **Line endings**: Both `\n` (Unix) and `\r\n` (Windows) are recognized as line terminators.
+3. **Blank lines**: Lines containing only whitespace are ignored. They serve as visual separators.
+4. **Comment lines**: Lines where the first character is `#` are comments and ignored.
+   To match a file starting with `#`, escape it: `\#`.
+5. **Trailing whitespace**: Trailing spaces are stripped from the pattern, **unless** they
+   are escaped with `\`. For example:
+   - `foo   ` → parsed as `foo` (trailing spaces stripped)
+   - `foo\ ` → parsed as `foo ` (one trailing space preserved)
+   - `foo\\ ` → parsed as `foo\` (the `\\` is a literal `\`, trailing space stripped)
+6. **Negation prefix**: If the line starts with `!`, it's a negation pattern — it
+   **un-ignores** files that were previously ignored by an earlier pattern.
+   To match a file starting with `!`, escape it: `\!`.
+7. **Trailing `/`**: If the pattern ends with `/`, the slash is removed and the pattern
+   is marked as **directory-only** — it will only match directories, not regular files.
+8. **Leading `/`**: A leading `/` anchors the pattern to the directory containing the
+   `.gitignore` file (see anchoring rules below). The `/` itself is stripped from the pattern.
+
+### 2.2 Pattern Flags
+
+After parsing, each pattern has these computed flags:
+
+| Flag | Condition | Effect |
+|------|-----------|--------|
+| **Negative** | Line started with `!` | Match means "un-ignore" instead of "ignore" |
+| **MustBeDir** | Line ended with `/` | Pattern only matches directories |
+| **NoDir** | Pattern contains no `/` (after stripping leading `/` and trailing `/`) | Pattern is matched against the **basename** only (not the full path) |
+| **EndsWith** | Pattern starts with `*` and the rest has no wildcards (e.g., `*.txt`) | Optimization: can use suffix matching instead of full wildmatch |
+
+### 2.3 Anchoring Rules
+
+This is one of the most important and subtle aspects of `.gitignore`:
+
+- **Unanchored** (no `/` in pattern): The pattern matches the **filename (basename) only**,
+  at any directory depth. Example: `*.o` ignores `foo.o`, `src/bar.o`, `deep/nested/baz.o`.
+
+- **Anchored** (pattern contains `/` in beginning or middle): The pattern is matched against
+  the **full path relative to the `.gitignore` location**, using pathname mode (where `*` can't
+  cross `/`). Example: `doc/frotz` only matches `doc/frotz` relative to the `.gitignore`, not
+  `a/doc/frotz`.
+
+- A **leading `/`** forces anchoring but is then stripped. So `/foo` is equivalent to an anchored
+  pattern `foo` — it matches `foo` in the `.gitignore`'s directory only, not `a/foo`.
+
+- A **trailing `/`** does NOT count as a `/` for anchoring purposes. So `build/` is treated as
+  unanchored (the `/` is stripped and the pattern has no remaining `/`). It matches `build` and
+  `a/build` directories at any depth, but NOT regular files named `build`.
+
+- Both `doc/frotz` and `/doc/frotz` behave identically — a leading slash is redundant when
+  there is already a middle slash.
+
+### 2.4 Matching Algorithm for a Single `.gitignore`
+
+Given a list of parsed patterns and a path to check:
+
+```
+for each pattern in REVERSE order (last pattern first):
+    if pattern.MustBeDir and path is not a directory:
+        skip this pattern
+
+    if pattern.NoDir:
+        # Pattern has no slash → match against basename only
+        result = wildmatch(pattern, basename(path), flags=0)
+    else:
+        # Pattern has slash → match against full relative path
+        result = wildmatch(pattern, relativePath, flags=WM_PATHNAME)
+
+    if result == match:
+        if pattern.Negative:
+            return NOT_IGNORED
+        else:
+            return IGNORED
+
+return UNDECIDED  # no pattern matched
+```
+
+Key points:
+- **Last match wins**: patterns are checked from bottom to top; the first match found
+  (= the last matching line in the file) determines the outcome.
+- **Basename matching uses no flags** (plain mode): this means `*` CAN match `/` in the
+  basename... but basenames don't contain `/`, so this is only relevant for unanchored
+  patterns.
+- **Full path matching uses `WM_PATHNAME`**: `*` cannot cross `/`, `**` can.
+- If `WM_CASEFOLD` is needed (case-insensitive filesystem), add it to the flags.
+
+### 2.5 Parsing Test Cases
+
+These test the line-parsing rules from section 2.1:
+
+| Input line | Parsed pattern | Negative | MustBeDir | NoDir | Note |
+|------------|---------------|:--------:|:---------:|:-----:|------|
+| `foo` | `foo` | | | yes | Simple basename pattern |
+| `*.txt` | `*.txt` | | | yes | Unanchored wildcard (EndsWith optimization) |
+| `foo/` | `foo` | | yes | yes | Trailing `/` → directory only; no remaining `/` → NoDir |
+| `foo/bar` | `foo/bar` | | | | Contains `/` → anchored to .gitignore location |
+| `/foo` | `foo` | | | yes | Leading `/` stripped; no remaining `/` → NoDir, but anchored |
+| `/foo/bar` | `foo/bar` | | | | Leading `/` stripped; still has `/` → anchored |
+| `!foo` | `foo` | yes | | yes | Negation |
+| `\!foo` | `!foo` | | | yes | Escaped `!` — literal |
+| `\#comment` | `#comment` | | | yes | Escaped `#` — literal |
+| `# comment` | *(skipped)* | | | | Comment line |
+| *(empty)* | *(skipped)* | | | | Blank line |
+| `foo   ` | `foo` | | | yes | Trailing spaces stripped |
+| `foo\ ` | `foo ` | | | yes | Trailing escaped space preserved |
+| `foo\\ ` | `foo\` | | | yes | `\\` = literal `\`, trailing space stripped |
+| `**/foo` | `**/foo` | | | | Contains `/` → anchored |
+| `foo/**` | `foo/**` | | | | Contains `/` → anchored |
+| `foo/**/bar` | `foo/**/bar` | | | | Contains `/` → anchored |
+| `!build/` | `build` | yes | yes | yes | Negated directory-only pattern |
+
+**Important edge case — leading `/` + anchoring**:
+
+The pattern `/foo` is anchored (it means "only match `foo` at this directory level"), but
+after stripping the `/`, the remaining pattern `foo` has no `/`, so it gets `NoDir` flag.
+This is special: despite having `NoDir`, git still knows it's anchored because the
+original line had a leading `/`. In practice, the leading `/` information should be tracked
+separately from the `NoDir` flag.
+
+Actually, looking at Git's implementation more carefully: [`parse_path_pattern()`](https://github.com/git/git/blob/master/dir.c#L697-L733) strips the
+`!` but does NOT strip the leading `/`. The leading `/` remains in the pattern string.
+The `NODIR` flag is computed AFTER `!` is stripped but WITH the leading `/` still present.
+So `/foo` → pattern is `/foo`, which contains `/`, so `NODIR` is NOT set. The leading `/`
+is stripped later during matching, in [`match_pathname()`](https://github.com/git/git/blob/master/dir.c#L1352-L1415).
+
+Corrected table:
+
+| Input line | Stored pattern | Negative | MustBeDir | NoDir | Note |
+|------------|---------------|:--------:|:---------:|:-----:|------|
+| `foo` | `foo` | | | yes | No `/` → basename match |
+| `*.txt` | `*.txt` | | | yes | No `/` → basename match |
+| `foo/` | `foo` | | yes | yes | Trailing `/` stripped, marked MustBeDir |
+| `foo/bar` | `foo/bar` | | | | Has `/` → full path match |
+| `/foo` | `/foo` | | | | Has `/` → full path match; `/` stripped at match time |
+| `/foo/bar` | `/foo/bar` | | | | Has `/` → full path match |
+| `!foo` | `foo` | yes | | yes | Negation prefix stripped |
+| `!foo/bar` | `foo/bar` | yes | | | Negation prefix stripped |
+| `doc/frotz/` | `doc/frotz` | | yes | | Trailing `/` stripped; has `/` → full path |
+
+### 2.6 Whitespace Handling Test Cases
+
+From [`t/t0008-ignores.sh` lines 865-912](https://github.com/git/git/blob/master/t/t0008-ignores.sh#L865-L912):
+
+| Pattern in file | Matches path | Note |
+|-----------------|-------------|------|
+| `trailing···` (3 spaces) | `trailing` | Trailing unescaped spaces stripped |
+| `trailing\·\·` (escaped spaces) | `trailing··` | Escaped spaces preserved |
+| `trailing 1 \····` (`\` then spaces) | `trailing 1 ` | `\` escapes one space, rest stripped |
+| `trailing 2 \\\\` | `trailing 2 \\` | `\\` pairs are literal `\`; no trailing spaces |
+| `trailing 3 \\\\·` (space after) | `trailing 3 \\` | `\\` are literal `\`; trailing space stripped |
+| `trailing 4   \\\····` | `trailing 4   \ ` | Three `\`: `\\` = literal `\`, `\·` = literal space, rest stripped |
+| `trailing 5 \\ \\\···` | `trailing 5 \ \ ` | `\\` = `\`, space, `\\` = `\`, `\·` = space, rest stripped |
+| `trailing 6 \\a\\` | `trailing 6 \a\` | Escaped chars in middle |
+
+(In the table above, `·` represents a space character for clarity.)
+
+---
+
+## Part 3: Gitignore Matching Semantics
+
+### 3.1 Multi-Level `.gitignore` Precedence
+
+A project can have `.gitignore` files at multiple directory levels:
+
+```
+.gitignore              ← root level
+src/.gitignore          ← src/ level
+src/vendor/.gitignore   ← src/vendor/ level
+```
+
+**Precedence rule**: A `.gitignore` closer to the path being checked takes priority over
+one further away. Within a single `.gitignore`, later lines override earlier lines.
+
+In practice, this means checking patterns from the deepest `.gitignore` first, then
+walking up to the root `.gitignore`. The first match found (from the deepest, latest
+pattern) determines the outcome.
+
+### 3.2 Negation
+
+A pattern starting with `!` **un-ignores** a previously ignored file:
+
+```gitignore
+*.log       # ignore all .log files
+!important.log  # but keep important.log
+```
+
+**Critical limitation**: You cannot un-ignore a file if its **parent directory** is
+excluded. When a directory is ignored, its contents are never even enumerated, so negation
+patterns on files inside it have no effect:
+
+```gitignore
+build/          # ignore build directory
+!build/output   # THIS DOES NOT WORK — build/ is already excluded
+```
+
+To work around this, you must un-ignore the directory first:
+
+```gitignore
+build/
+!build/
+build/*
+!build/output
+```
+
+### 3.3 Directory-Only Patterns
+
+A pattern ending with `/` only matches directories:
+
+```gitignore
+logs/    # ignores the "logs" directory (and everything inside it)
+         # does NOT ignore a regular file named "logs"
+```
+
+When matching, the caller must provide information about whether the path is a directory.
+
+### 3.4 How Patterns Match Paths
+
+Summary of the matching flow:
+
+```
+is_ignored(path, isDir):
+    for each .gitignore file, from deepest to root:
+        for each pattern in file, from LAST to FIRST:
+            if pattern.MustBeDir and not isDir:
+                continue
+
+            if pattern.NoDir:
+                matched = wildmatch(pattern, basename(path), 0)
+            else:
+                rel = path relative to this .gitignore's directory
+                matched = wildmatch(pattern, rel, WM_PATHNAME)
+
+            if matched:
+                if pattern.Negative:
+                    return false  # un-ignored
+                else:
+                    return true   # ignored
+
+    return false  # not ignored by default
+```
+
+---
+
+## Part 4: Integration Test Cases
+
+These test scenarios are extracted from Git's test suites and exercise the full pipeline:
+parsing + matching + precedence + negation.
+
+### 4.1 Multi-Level Setup
+
+This is the primary test fixture from [`t/t0008-ignores.sh`](https://github.com/git/git/blob/master/t/t0008-ignores.sh#L179-L232):
+
+```
+.gitignore:
+    one
+    ignored-*
+    top-level-dir/
+
+a/.gitignore:
+    two*
+    *three
+
+a/b/.gitignore:
+    four
+    five
+    # this is a comment (line 3)
+    six
+    ignored-dir/
+    # blank line follows (line 6):
+
+    !on*
+    !two
+```
+
+### 4.2 Basic Pattern Matching
+
+| Path | isDir | Ignored? | Matched by | Note |
+|------|:-----:|:--------:|-----------|------|
+| `one` | no | **yes** | `.gitignore:1:one` | Exact basename match |
+| `a/one` | no | **yes** | `.gitignore:1:one` | `one` has no `/` → matches basename at any depth |
+| `not-ignored` | no | **no** | — | No matching pattern |
+| `a/not-ignored` | no | **no** | — | No matching pattern |
+| `ignored-and-untracked` | no | **yes** | `.gitignore:2:ignored-*` | Wildcard basename match |
+| `a/ignored-and-untracked` | no | **yes** | `.gitignore:2:ignored-*` | Basename match at depth |
+| `top-level-dir` | yes | **yes** | `.gitignore:3:top-level-dir/` | Directory-only pattern |
+| `top-level-dir` | no | **no** | — | Not a directory → `top-level-dir/` doesn't match |
+
+### 4.3 Sub-Directory Local Patterns
+
+| Path | isDir | Ignored? | Matched by | Note |
+|------|:-----:|:--------:|-----------|------|
+| `a/3-three` | no | **yes** | `a/.gitignore:2:*three` | `*three` matches basename `3-three` |
+| `a/three-not-this-one` | no | **no** | — | `*three` doesn't match (doesn't end with `three`) |
+| `a/b/four` | no | **yes** | `a/b/.gitignore:1:four` | Exact basename match |
+| `a/b/six` | no | **yes** | `a/b/.gitignore:4:six` | Line 4 (comments/blanks counted) |
+
+### 4.4 Negation in Nested `.gitignore`
+
+| Path | isDir | Ignored? | Matched by | Note |
+|------|:-----:|:--------:|-----------|------|
+| `a/b/one` | no | **no** | `a/b/.gitignore:8:!on*` | `one` matches `!on*` → un-ignored. Without this negation, would match `.gitignore:1:one` |
+| `a/b/on` | no | **no** | `a/b/.gitignore:8:!on*` | `on` matches `!on*` → un-ignored |
+| `a/b/two` | no | **no** | `a/b/.gitignore:9:!two` | `two` matches `!two` → un-ignored. Without this, would match `a/.gitignore:1:two*` |
+| `a/b/twooo` | no | **yes** | `a/.gitignore:1:two*` | Matches `two*`; NOT negated by `!two` (not an exact match) |
+| `a/b/one one` | no | **no** | `a/b/.gitignore:8:!on*` | Space in filename; `!on*` still matches |
+
+### 4.5 Ignored Sub-Directories
+
+| Path | isDir | Ignored? | Matched by | Note |
+|------|:-----:|:--------:|-----------|------|
+| `a/b/ignored-dir` | yes | **yes** | `a/b/.gitignore:5:ignored-dir/` | Directory-only pattern matches directory |
+| `a/b/ignored-dir/foo` | no | **yes** | `a/b/.gitignore:5:ignored-dir/` | Parent dir is ignored → contents inherited |
+| `a/b/ignored-dir/twoooo` | no | **yes** | `a/b/.gitignore:5:ignored-dir/` | Parent dir ignored, overrides `two*` |
+| `a/b/ignored-dir/seven` | no | **yes** | `a/b/.gitignore:5:ignored-dir/` | Even though `a/b/ignored-dir/.gitignore` has `seven`, parent dir exclusion takes precedence |
+
+### 4.6 Negation Cannot Override Parent Directory Exclusion
+
+From [`t/t3001-ls-files-others-exclude.sh`](https://github.com/git/git/blob/master/t/t3001-ls-files-others-exclude.sh#L178-L194):
+
+```gitignore
+# Given these command-line exclude patterns:
+--exclude="one" --exclude="!one/a.1"
+```
+
+| Path | Ignored? | Note |
+|------|:--------:|------|
+| `one/a.1` | **yes** | `one` directory is excluded; `!one/a.1` cannot override it |
+| `one/a.2` | **yes** | Everything inside `one/` is excluded |
+
+Conversely, negating a directory doesn't un-negate individual files:
+
+```gitignore
+--exclude="!one" --exclude="one/a.1"
+```
+
+| Path | Ignored? | Note |
+|------|:--------:|------|
+| `one/a.1` | **yes** | `one/a.1` pattern overrides `!one` |
+
+### 4.7 Trailing Slash — Directory vs File
+
+From [`t/t3001-ls-files-others-exclude.sh`](https://github.com/git/git/blob/master/t/t3001-ls-files-others-exclude.sh#L157-L170):
+
+```gitignore
+two/
+```
+
+| Path | isDir | Ignored? | Note |
+|------|:-----:|:--------:|------|
+| `two` (directory) | yes | **yes** | Pattern `two/` matches directory |
+| `two` (regular file) | no | **no** | Pattern `two/` does NOT match regular file |
+
+### 4.8 `**` Patterns
+
+**Example 1**: Selective exclusion with `**` (from [t0008](https://github.com/git/git/blob/master/t/t0008-ignores.sh#L833-L848)):
+
+```gitignore
+data/**
+!data/**/
+!data/**/*.txt
+```
+
+| Path | isDir | Ignored? | Note |
+|------|:-----:|:--------:|------|
+| `data/file` | no | **yes** | Matches `data/**`; no negation matches |
+| `data/data1/file1` | no | **yes** | Matches `data/**`; not a dir, not `.txt` |
+| `data/data1/file1.txt` | no | **no** | Matches `data/**`, then un-ignored by `!data/**/*.txt` |
+| `data/data2/file2` | no | **yes** | Matches `data/**`; not `.txt` |
+| `data/data2/file2.txt` | no | **no** | Un-ignored by `!data/**/*.txt` |
+| `data/data1` | yes | **no** | Un-ignored by `!data/**/` (directory negation) |
+
+**Example 2**: `**` boundary (from [t0008](https://github.com/git/git/blob/master/t/t0008-ignores.sh#L850-L859)):
+
+```gitignore
+foo**/bar
+```
+
+| Path | isDir | Ignored? | Note |
+|------|:-----:|:--------:|------|
+| `foobar` | no | **no** | `foo**/bar`: `**` not at boundary → treated as `*` in pathname mode; `foobar` ≠ `foo<anything>bar` split by `/` |
+| `foo/bar` | no | **yes** | Matches: `foo` then `**/bar` |
+
+**Example 3**: `**/` matching anywhere (from [t3001](https://github.com/git/git/blob/master/t/t3001-ls-files-others-exclude.sh#L284-L293)):
+
+```gitignore
+**/a.1
+```
+
+| Path | Ignored? | Note |
+|------|:--------:|------|
+| `a.1` | **yes** | `**/` matches at root level |
+| `one/a.1` | **yes** | `**/` matches one directory |
+| `one/two/a.1` | **yes** | `**/` matches two directories |
+| `three/a.1` | **yes** | `**/` matches any directory |
+
+### 4.9 Exact Prefix Matching — `/dir/` Doesn't Match `dir-suffix/`
+
+From [`t/t0008-ignores.sh`](https://github.com/git/git/blob/master/t/t0008-ignores.sh#L807-L831):
+
+With `a/.gitignore` containing `/git/`:
+
+| Path | isDir | Ignored? | Note |
+|------|:-----:|:--------:|------|
+| `a/git` | yes | **yes** | `/git/` matches directory `git` |
+| `a/git/foo` | no | **yes** | Inside ignored directory |
+| `a/git-foo` | yes | **no** | `git-foo` ≠ `git` — no prefix/substring matching |
+| `a/git-foo/bar` | no | **no** | Parent not ignored |
+
+Same behavior with `git/` (without leading `/`):
+
+| Path | isDir | Ignored? | Note |
+|------|:-----:|:--------:|------|
+| `a/git` | yes | **yes** | `git/` anchored (contains `/` after stripping trailing `/`… actually `git` has no `/`, so it's unanchored basename match on directories) |
+| `a/git/foo` | no | **yes** | Inside ignored directory |
+| `a/git-foo` | yes | **no** | `git-foo` ≠ `git` |
+| `a/git-foo/bar` | no | **no** | Parent not ignored |
+
+### 4.10 Pattern Interaction — Complex Scenario
+
+From [`t/t3001-ls-files-others-exclude.sh`](https://github.com/git/git/blob/master/t/t3001-ls-files-others-exclude.sh#L13-L76), a comprehensive test with multiple pattern
+sources working together:
+
+```
+.gitignore:          *.1  /*.3  !*.6
+one/.gitignore:      *.2  two/*.4  !*.7  *.8
+one/two/.gitignore:  !*.2  !*.8
+```
+
+Plus a global exclude file: `*.7  !*.8` and a command-line exclude: `*.6`
+
+Files in each of `.`, `one/`, `one/two/`, `three/`:
+`a.1` through `a.8`
+
+Expected untracked (not excluded) files:
+
+| Path | Note |
+|------|------|
+| `a.2` | Not matched by `*.1` or `/*.3` or `*.6` |
+| `a.4` | Not matched |
+| `a.5` | Not matched |
+| `a.8` | Matched by global `*.7` but un-ignored by `!*.8` |
+| `one/a.3` | `/*.3` is anchored to root → doesn't match `one/a.3` |
+| `one/a.4` | `two/*.4` only matches in `two/` subdir |
+| `one/a.5` | Not matched |
+| `one/a.7` | Matched by global `*.7` but un-ignored by `one/.gitignore:!*.7` |
+| `one/two/a.2` | Matched by `one/.gitignore:*.2` but un-ignored by `one/two/.gitignore:!*.2` |
+| `one/two/a.3` | `/*.3` anchored to root → doesn't match here |
+| `one/two/a.5` | Not matched |
+| `one/two/a.7` | Un-ignored by `one/.gitignore:!*.7` |
+| `one/two/a.8` | Matched by `one/.gitignore:*.8` but un-ignored by `one/two/.gitignore:!*.8` |
+| `three/a.2` | Not matched by root `*.1` or `/*.3` |
+| `three/a.3` | `/*.3` anchored to root → doesn't match `three/a.3` |
+| `three/a.4` | Not matched |
+| `three/a.5` | Not matched |
+| `three/a.8` | Matched by global `*.7` but un-ignored by `!*.8` |
+
+### 4.11 Edge Cases
+
+**UTF-8 BOM**: A `.gitignore` file starting with the UTF-8 BOM (`\xEF\xBB\xBF`) should
+have the BOM stripped before parsing. The BOM must not become part of the first pattern.
+
+**CRLF line endings**: Files with `\r\n` line endings (Windows-style) must be parsed
+identically to `\n`-only files.
+
+**Symlink `.gitignore`**: A `.gitignore` file that is a symbolic link should NOT be
+followed when it's inside the working tree. This is a security measure to prevent
+symlink attacks. The patterns from such a file should be silently ignored (Git logs a
+warning: "unable to access .gitignore").
+
+**Large `.gitignore` files**: Files exceeding ~100 MB should be rejected with a warning
+and their patterns ignored.
+
+---
+
+## Part 5: Gitattributes — Differences from Gitignore
+
+`.gitattributes` files assign attributes (like `binary`, `text`, `diff`, `merge`, etc.)
+to paths using the **same pattern matching engine** as `.gitignore`. If you are implementing
+both `.gitignore` and `.gitattributes`, the wildmatch engine and the core matching logic
+(Parts 1-3) are fully shared. This section documents only the differences.
+
+### 5.1 Shared Code
+
+Both `.gitignore` and `.gitattributes` use:
+- The same [`parse_path_pattern()`](https://github.com/git/git/blob/master/dir.c#L697-L733) function to parse patterns into flags
+- The same [`match_basename()`](https://github.com/git/git/blob/master/dir.c#L1328-L1350) and [`match_pathname()`](https://github.com/git/git/blob/master/dir.c#L1352-L1415) functions
+- The same [`wildmatch()`](https://github.com/git/git/blob/master/wildmatch.c#L286-L290) engine with the same flags
+
+This means all wildmatch test cases (Part 1), anchoring rules, `NODIR`/`MUSTBEDIR` flag logic,
+and basename-vs-fullpath matching behavior are identical.
+
+### 5.2 Differences
+
+| Aspect | `.gitignore` | `.gitattributes` |
+|--------|-------------|-----------------|
+| **Purpose** | Determines if a path is ignored (excluded from tracking) | Assigns attributes (key-value pairs) to paths |
+| **Line format** | Entire line is the pattern | `pattern attr1 attr2 ...` — pattern is the first whitespace-delimited token, rest are attributes |
+| **Negation (`!` prefix)** | `!pattern` un-ignores previously ignored files | **Forbidden**. Git warns "Negative patterns are ignored in git attributes" and skips the line. Use `\!` to match a literal `!`. |
+| **Directory recursion** | `dir/` excludes the directory AND all its contents (Git skips traversal into excluded dirs) | `dir/` matches the directory entry only, **NOT** its contents. The docs say: "using the trailing-slash `path/` syntax is pointless in an attributes file; use `path/**` instead" |
+| **Override granularity** | Last matching pattern wins — the entire match decision comes from one pattern | **Per-attribute** override — multiple patterns can match the same path, and each pattern contributes its own attributes. Later lines override earlier lines on a per-attribute basis. |
+| **C-style quoting** | Not supported | Patterns starting with `"` are parsed as C-style quoted strings (supports spaces, special chars in filenames) |
+| **Leading whitespace** | Part of the pattern (not stripped) | Stripped before parsing |
+| **Trailing whitespace** | Stripped unless escaped with `\` (see `trim_trailing_spaces()`) | Not applicable — the pattern ends at the first whitespace; everything after is the attribute list |
+| **Macro definitions** | Not applicable | Lines starting with `[attr]` define macro attributes: `[attr]binary -diff -merge -text` |
+| **Max line length** | No per-line limit (only overall file size ~100MB) | 2048 bytes per line ([`ATTR_MAX_LINE_LENGTH`](https://github.com/git/git/blob/master/attr.c#L335-L338)) |
+| **Attribute states** | N/A (binary: ignored or not) | `attr` (set/true), `-attr` (unset/false), `!attr` (unspecified/reset), `attr=value` (custom value) |
+
+### 5.3 Line Parsing
+
+A `.gitattributes` line is parsed as follows (from [`attr.c:parse_attr_line()`](https://github.com/git/git/blob/master/attr.c#L321-L410)):
+
+1. Strip leading whitespace (spaces, tabs, `\r`, `\n`)
+2. Skip blank lines and lines starting with `#` (comments)
+3. If the line starts with `"`, C-style unquote the pattern
+4. Otherwise, the pattern is the first whitespace-delimited token
+5. If the line starts with `[attr]`, it's a macro definition (not a pattern)
+6. The pattern is passed to `parse_path_pattern()` — same function as `.gitignore`
+7. If `PATTERN_FLAG_NEGATIVE` is set (pattern started with `!`), reject with a warning
+8. The remaining tokens are parsed as attributes
+
+### 5.4 Matching Algorithm
+
+```
+get_attributes(path, isDir):
+    for each attribute to resolve:
+        value = UNSPECIFIED
+
+    for each .gitattributes file, from deepest to root:
+        for each pattern in file, from LAST to FIRST:
+            if pattern.MustBeDir and not isDir:
+                continue
+            if pattern is a macro definition:
+                continue
+
+            if pattern.NoDir:
+                matched = wildmatch(pattern, basename(path), 0)
+            else:
+                rel = path relative to this .gitattributes's directory
+                matched = wildmatch(pattern, rel, WM_PATHNAME)
+
+            if matched:
+                for each attribute in this pattern's attribute list:
+                    if attribute.value is still UNSPECIFIED:
+                        attribute.value = this pattern's value
+                        # (macros are expanded here too)
+
+    return resolved attributes
+```
+
+Key difference from `.gitignore`: matching does **not** stop at the first match. All
+matching patterns contribute, but only the first (= latest in file) value for each
+attribute is kept.
+
+### 5.5 Test Cases — Basic Attribute Matching
+
+From [`t/t0003-attributes.sh`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L70-L158):
+
+**Fixture:**
+```
+.gitattributes:
+    " d "   test=d          # C-quoted pattern with spaces
+     e      test=e          # leading space stripped
+    f       test=f
+    a/i     test=a/i        # anchored (contains /)
+    onoff   test -test      # set then unset
+    offon   -test test      # unset then set
+    no      notest          # different attribute
+    A/e/F   test=A/e/F      # mixed case anchored
+
+a/.gitattributes:
+    g       test=a/g
+    b/g     test=a/b/g      # anchored within a/
+
+a/b/.gitattributes:
+    h       test=a/b/h
+    d/*     test=a/b/d/*    # wildcard anchored
+    d/yes   notest          # sets notest, not test
+```
+
+| Path | `test` attribute | Note |
+|------|:----------------:|------|
+| ` d ` | `d` | C-quoted pattern `" d "` matches filename with spaces |
+| `e` | `e` | Leading space in pattern stripped |
+| `f` | `f` | Basename match |
+| `a/f` | `f` | `f` has no `/` → basename match at any depth |
+| `a/c/f` | `f` | Works at deeper levels too |
+| `a/g` | `a/g` | `a/.gitattributes:g` matches basename `g` under `a/` |
+| `a/b/g` | `a/b/g` | `a/.gitattributes:b/g` (anchored) is last match |
+| `b/g` | unspecified | `a/.gitattributes` patterns don't apply outside `a/` |
+| `a/b/h` | `a/b/h` | `a/b/.gitattributes:h` matches |
+| `a/b/d/g` | `a/b/d/*` | `d/*` in `a/b/.gitattributes` matches |
+| `onoff` | unset | `test -test` — later `-test` wins (per-attr: last state) |
+| `offon` | set | `-test test` — later `test` wins |
+| `no` | unspecified | `no notest` sets `notest` attr, not `test` |
+| `a/b/d/no` | `a/b/d/*` | `d/*` sets `test=a/b/d/*`; `notest` also set from same line |
+| `a/b/d/yes` | unspecified | `d/yes notest` sets `notest` but NOT `test` |
+| `a/i` | `a/i` | `a/i` has `/` → anchored to root |
+| `subdir/a/i` | unspecified | `a/i` is anchored → doesn't match under `subdir/` |
+
+### 5.6 Test Cases — Case Sensitivity
+
+From [`t/t0003-attributes.sh`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L160-L204):
+
+With `core.ignorecase=0` (case-sensitive, default):
+
+| Path | `test` attribute | Note |
+|------|:----------------:|------|
+| `F` | unspecified | `f` doesn't match `F` |
+| `a/F` | unspecified | Case-sensitive: no match |
+| `a/b/G` | unspecified | `g` doesn't match `G` |
+| `a/E/f` | `f` | `f` basename matches (directory case doesn't matter for basename patterns) |
+| `A/e/F` | unspecified | Pattern `A/e/F` doesn't match because path components are checked case-sensitively |
+
+With `core.ignorecase=1` (case-insensitive):
+
+| Path | `test` attribute | Note |
+|------|:----------------:|------|
+| `F` | `f` | `f` matches `F` with casefold |
+| `a/F` | `f` | Casefold basename match |
+| `a/b/G` | `a/b/g` | Casefold: `G` matches `g` |
+| `a/b/H` | `a/b/h` | Casefold match |
+| `a/E/f` | `A/e/F` | Casefold: `A/e/F` pattern matches `a/E/f` |
+| `oNoFf` | unset | Casefold: matches `onoff` pattern |
+
+### 5.7 Test Cases — `**` Patterns
+
+From [`t/t0003-attributes.sh`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L287-L322):
+
+**`**/f` (with slashes):**
+```gitattributes
+**/f foo=bar
+```
+
+| Path | `foo` attribute | Note |
+|------|:---------------:|------|
+| `f` | `bar` | `**/` matches at root |
+| `a/f` | `bar` | `**/` matches one directory |
+| `a/b/f` | `bar` | `**/` matches two directories |
+| `a/b/c/f` | `bar` | `**/` matches any depth |
+
+**`a**f` (no slashes — `**` not at boundary):**
+```gitattributes
+a**f foo=bar
+```
+
+| Path | `foo` attribute | Note |
+|------|:---------------:|------|
+| `f` | unspecified | Doesn't start with `a` |
+| `af` | `bar` | `a` + `**`(as `*`) + `f` |
+| `axf` | `bar` | `a` + `**`(as `*`) matches `x` + `f` |
+| `a/f` | unspecified | `**` not at boundary → treated as `*` in pathname mode; `*` can't cross `/` |
+| `a/b/f` | unspecified | Same: `*` can't cross `/` |
+| `a/b/c/f` | unspecified | Same |
+
+### 5.8 Test Cases — Negative Pattern Rejection
+
+From [`t/t0003-attributes.sh`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L276-L285):
+
+```gitattributes
+!f test=bar
+```
+Result: Warning "Negative patterns are ignored in git attributes". The pattern is skipped.
+
+```gitattributes
+\!f test=foo
+```
+Result: File named `!f` gets attribute `test=foo`. The `\!` escapes the `!`.
+
+### 5.9 Test Cases — Prefix Matching
+
+From [`t/t0003-attributes.sh`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L224-L232):
+
+| Path | `test` attribute | Note |
+|------|:----------------:|------|
+| `a/g` | `a/g` | Matches `a/.gitattributes:g` |
+| `a_plus/g` | unspecified | `a_plus/` is NOT confused with `a/` prefix |
+
+### 5.10 Test Cases — Macro Expansion
+
+From [`t/t0003-attributes.sh`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L489-L506):
+
+```gitattributes
+file binary
+```
+
+The built-in macro `binary` is defined as `[attr]binary -diff -merge -text`.
+
+| Path | Attribute | Value | Note |
+|------|-----------|:-----:|------|
+| `file` | `binary` | set | Direct macro attribute |
+| `file` | `diff` | unset | Expanded from `binary` → `-diff` |
+| `file` | `merge` | unset | Expanded from `binary` → `-merge` |
+| `file` | `text` | unset | Expanded from `binary` → `-text` |
+
+### 5.11 Test Cases — Symlinks and Large Files
+
+Same behavior as `.gitignore`:
+
+- **Symlink `.gitattributes` in working tree**: NOT followed (warning "unable to access .gitattributes")
+  — from [`t/t0003-attributes.sh:527-534`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L527-L534)
+- **Large attribute line** (>2048 bytes): Warning "ignoring overly long attributes line", line skipped
+  — from [`t/t0003-attributes.sh:536-543`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L536-L543)
+- **Large attribute file** (>100MB): Warning "ignoring overly large gitattributes file", file skipped
+  — from [`t/t0003-attributes.sh:558-563`](https://github.com/git/git/blob/master/t/t0003-attributes.sh#L558-L563)
+
+---
+
+## Appendix: Git Source Cross-References
+
+### Shared (used by both `.gitignore` and `.gitattributes`)
+
+| Concept | Git source location |
+|---------|-------------------|
+| Wildmatch engine | [`wildmatch.c:59-290`](https://github.com/git/git/blob/master/wildmatch.c#L59-L290) (function `dowild`) |
+| Wildmatch public API | [`wildmatch.h`](https://github.com/git/git/blob/master/wildmatch.h) |
+| Glob special chars (`*?[\`) | [`sane-ctype.h:47`](https://github.com/git/git/blob/master/sane-ctype.h#L47) (`is_glob_special`) |
+| Pattern parsing | [`dir.c:697-733`](https://github.com/git/git/blob/master/dir.c#L697-L733) (`parse_path_pattern`) |
+| Basename matching | [`dir.c:1328-1350`](https://github.com/git/git/blob/master/dir.c#L1328-L1350) (`match_basename`) |
+| Full path matching | [`dir.c:1352-1415`](https://github.com/git/git/blob/master/dir.c#L1352-L1415) (`match_pathname`) |
+| Pattern flags | [`dir.h:52-55`](https://github.com/git/git/blob/master/dir.h#L52-L55) (`PATTERN_FLAG_*`) |
+| Wildmatch test suite | [`t/t3070-wildmatch.sh`](https://github.com/git/git/blob/master/t/t3070-wildmatch.sh) |
+
+### Gitignore-specific
+
+| Concept | Git source location |
+|---------|-------------------|
+| Trailing space stripping | [`dir.c:1029-1050`](https://github.com/git/git/blob/master/dir.c#L1029-L1050) (`trim_trailing_spaces`) |
+| File buffer parsing (BOM, CRLF, comments) | [`dir.c:1226-1254`](https://github.com/git/git/blob/master/dir.c#L1226-L1254) (`add_patterns_from_buffer`) |
+| Pattern list scanning (last match wins) | [`dir.c:1423-1469`](https://github.com/git/git/blob/master/dir.c#L1423-L1469) (`last_matching_pattern_from_list`) |
+| Multi-source precedence | [`dir.c:1624-1643`](https://github.com/git/git/blob/master/dir.c#L1624-L1643) (`last_matching_pattern_from_lists`) |
+| Public exclude check API | [`dir.c:1831-1839`](https://github.com/git/git/blob/master/dir.c#L1831-L1839) (`is_excluded`) |
+| Gitignore test suite | [`t/t0008-ignores.sh`](https://github.com/git/git/blob/master/t/t0008-ignores.sh) |
+| ls-files exclude tests | [`t/t3001-ls-files-others-exclude.sh`](https://github.com/git/git/blob/master/t/t3001-ls-files-others-exclude.sh) |
+| Official gitignore docs | [`Documentation/gitignore.adoc`](https://github.com/git/git/blob/master/Documentation/gitignore.adoc) |
+
+### Gitattributes-specific
+
+| Concept | Git source location |
+|---------|-------------------|
+| Attribute line parsing | [`attr.c:321-410`](https://github.com/git/git/blob/master/attr.c#L321-L410) (`parse_attr_line`) |
+| Calls shared `parse_path_pattern()` | [`attr.c:385-388`](https://github.com/git/git/blob/master/attr.c#L385-L388) |
+| Negative pattern rejection | [`attr.c:389-393`](https://github.com/git/git/blob/master/attr.c#L389-L393) |
+| Attribute value parsing | [`attr.c:276-319`](https://github.com/git/git/blob/master/attr.c#L276-L319) (`parse_attr`) |
+| Path matching (calls shared funcs) | [`attr.c:1045-1066`](https://github.com/git/git/blob/master/attr.c#L1045-L1066) (`path_matches`) |
+| Per-attribute fill logic | [`attr.c:1092-1115`](https://github.com/git/git/blob/master/attr.c#L1092-L1115) (`fill_one`) |
+| Stack scanning | [`attr.c:1117-1135`](https://github.com/git/git/blob/master/attr.c#L1117-L1135) (`fill`) |
+| Macro expansion | [`attr.c:1109-1110`](https://github.com/git/git/blob/master/attr.c#L1109-L1110) (in `fill_one`) |
+| Built-in macros | [`attr.c:638-641`](https://github.com/git/git/blob/master/attr.c#L638-L641) (`binary`) |
+| Data structures | [`attr.h:253-281`](https://github.com/git/git/blob/master/attr.h#L253-L281) (`struct pattern`, `struct match_attr`) |
+| Gitattributes test suite | [`t/t0003-attributes.sh`](https://github.com/git/git/blob/master/t/t0003-attributes.sh) |
+| Archive attr pattern tests | [`t/t5002-archive-attr-pattern.sh`](https://github.com/git/git/blob/master/t/t5002-archive-attr-pattern.sh) |
+| Official gitattributes docs | [`Documentation/gitattributes.adoc`](https://github.com/git/git/blob/master/Documentation/gitattributes.adoc) |


### PR DESCRIPTION
## Summary

- Adds `ParseGitAttributes()` to parse `.gitattributes` content and a `GitAttributes` type with methods for checking `linguist-vendored`, `linguist-documentation`, `linguist-generated`, `linguist-detectable`, and `linguist-language` attributes
- Implements git-style glob pattern matching (`*`, `**`, `?`, `[...]`, anchored patterns) compatible with linguist's `fnmatch(FNM_PATHNAME)`
- Updates the `enry` CLI to automatically read `.gitattributes` from the analyzed directory root
- Closes #27, addresses src-d/enry#18

## Design decisions

This implementation addresses all review comments from the abandoned PR (src-d/enry#50):

| Review concern | Resolution |
|---|---|
| Won't work on bare repos | Accepts `[]byte` content, not filesystem path |
| Use scanner/split by lines | Uses `bufio.Scanner` for line-by-line parsing |
| Multiple attributes per line | Fully supported, last matching rule wins |
| Resolve aliases | `GetLanguageByAlias()` called for canonical names |
| Git-style path matchers needed | Proper git glob matching, not Go regexps |
| No global variable | `GitAttributes` is a value type, no global state |
| Naming: uppercase A in GitAttributes | Consistent `GitAttributes` naming throughout |

## Test plan

- [x] All 38 new tests pass (`TestParseGitAttributes`, `TestMatchGitPattern`, `TestGitAttributesIs*`, `TestGitAttributesGetLanguage*`, `TestGitAttributesMultipleRules`, `TestGitAttributesLinguistCompatibility`)
- [x] Full existing test suite passes (`go test ./...`)
- [x] `go vet ./...` clean
- [ ] Manual test with `.gitattributes` in a real repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)