### PR TITLE
Treat `mise.lock` as generated.

### DIFF
--- a/data/generated.go
+++ b/data/generated.go
@@ -82,6 +82,9 @@ var GeneratedCodeNameMatchers = []GeneratedCodeNameMatcher{
 	// Deno lock
 	nameEndsWith("deno.lock"),
 
+	// Mise lock
+	nameMatches("(^|\/)mise(\.[^\/]+)?\.lock$"),
+
 	// NPM shrinkwrap
 	nameEndsWith("npm-shrinkwrap.json"),
 

--- a/data/generated.go
+++ b/data/generated.go
@@ -1,3 +1,10 @@
+// Package data contains generated-file detection rules used by enry.
+//
+// NOTE: This file is NOT produced by `make code-generate`.
+//       Unlike other files such as `extension.go`, `content.go`, `vendor.go`, and `documentation.go`,
+//       the generated-file rules here are maintained manually. As a result, upstream Linguist
+//       changes to generated-file detection like `lib/linguist/generated.rb` may need
+//       to be ported here separately, with corresponding tests in `utils_test.go`.
 package data
 
 import (

--- a/utils_test.go
+++ b/utils_test.go
@@ -283,6 +283,9 @@ func TestIsGenerated(t *testing.T) {
 		//Composer generated composer.lock file
 		{"JSON/composer.lock", false, true},
 
+		// Mise lock file
+		{"Dummy/mise.lock", false, true},
+
 		//Node modules
 		{"Dummy/node_modules/foo.js", false, true},
 


### PR DESCRIPTION
From https://github.com/github-linguist/linguist/pull/7923.