### PR TITLE
GetLanguagesByShebang: PostScript

### DIFF
--- a/common.go
+++ b/common.go
@@ -301,6 +301,9 @@ var (
 func getInterpreter(data []byte) string {
 	line := getFirstLine(data)
 	if !hasShebang(line) {
+		if bytes.HasPrefix(line, []byte("%!PS")) {
+			return "gs"
+		}
 		return ""
 	}
 

--- a/data/interpreter.go
+++ b/data/interpreter.go
@@ -60,6 +60,7 @@ var LanguagesByInterpreter = map[string][]string{
 	"gojq":              {"jq"},
 	"gosh":              {"Scheme"},
 	"groovy":            {"Groovy"},
+	"gs":                {"PostScript"},
 	"gsed":              {"sed"},
 	"guile":             {"Scheme"},
 	"hy":                {"Hy"},


### PR DESCRIPTION
This adds support for recognizing PostScript from the first line of the file.
PostScript has a sort-of shebang, but with `%!` instead of `#!`, so detection is implemented via `GetLanguagesByShebang()`